### PR TITLE
Replace cudaconvert with simple pure funtion.

### DIFF
--- a/src/CUDAnative.jl
+++ b/src/CUDAnative.jl
@@ -15,12 +15,11 @@ isfile(ext) || error("Unable to load $ext\n\nPlease re-run Pkg.build(\"CUDAnativ
 include(ext)
 
 include("util.jl")
-include("types.jl")
 
 include("jit.jl")
-include("execution.jl")
-include("device/intrinsics.jl")
 include("device/array.jl")
+include("device/intrinsics.jl") # these files contain generated functions,
+include("execution.jl")         # so should get loaded last (JuliaLang/julia#19942)
 
 
 function __init__()

--- a/src/device/array.jl
+++ b/src/device/array.jl
@@ -19,8 +19,6 @@ end
 CuDeviceArray{T,N}(shape::NTuple{N,Int}, p::Ptr{T}) = CuDeviceArray{T,N}(shape, p)
 CuDeviceArray{T}(len::Int, p::Ptr{T})               = CuDeviceArray{T,1}((len,), p)
 
-cudaconvert{T,N}(::Type{CuArray{T,N}}) = CuDeviceArray{T,N}
-
 Base.convert{T,N}(::Type{CuDeviceArray{T,N}}, a::CuArray{T,N}) =
     CuDeviceArray{T,N}(a.shape, Base.unsafe_convert(Ptr{T}, a.devptr))
 

--- a/src/execution.jl
+++ b/src/execution.jl
@@ -9,6 +9,34 @@ using Base.Iterators: filter
 # Auxiliary
 #
 
+# Determine which type to pre-convert objects to for use on a CUDA device.
+#
+# The resulting object type will be used as a starting point to determine the final
+# specialization and argument types (there might be other conversions, eg. factoring in the
+# ABI). This is different from `cconvert` in that we don't know which type to convert to.
+function convert_type(t)
+    # NOTE: this conversion was originally intended to be a user-extensible interface,
+    #       a la cconvert (look for cudaconvert in f1e592e61d6898869b918331e3e625292f4c8cab).
+    #
+    #       however, the generated function behind @cuda isn't allowed to call overloaded
+    #       functions (only pure ones), and also won't be able to see functions defined
+    #       after the generated function's body (see JuliaLang/julia#19942).
+
+    # Pointer handling
+    if t <: DevicePtr
+        return Ptr{t.parameters...}
+    elseif t <: Ptr
+        throw(InexactError())
+    end
+
+    # Array types
+    if t <: CuArray
+        return CuDeviceArray{t.parameters...}
+    end
+
+    return t
+end
+
 """
 Convert the arguments to a kernel function to their CUDA representation, and figure out what
 types to specialize the kernel function for and how to actually pass those objects.
@@ -20,7 +48,7 @@ function convert_arguments(args, tt)
     # convert types to their CUDA representation
     for i in 1:length(argexprs)
         t = argtypes[i]
-        ct = cudaconvert(t)
+        ct = convert_type(t)
         if ct != t
             argtypes[i] = ct
             if ct <: Ptr

--- a/src/execution.jl
+++ b/src/execution.jl
@@ -192,16 +192,6 @@ macro cuda(config::Expr, callexpr::Expr)
     end
 end
 
-# Execute a pre-compiled CUDA kernel
-@generated function generated_cuda(dims::Tuple{CuDim, CuDim},
-                                   cuda_fun::CuFunction, argspec...;
-                                   kwargs...)
-    tt = Base.to_tuple_type(argspec)
-    args = [:( argspec[$i] ) for i in 1:length(argspec)]
-
-    return emit_cudacall(:(cuda_fun), :(dims), :(kwargs), args, tt)
-end
-
 # Compile and execute a CUDA kernel from a Julia function
 const func_cache = Dict{UInt, CuFunction}()
 @generated function generated_cuda{F<:Core.Function}(dims::Tuple{CuDim, CuDim},

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,9 +1,0 @@
-# Determine which type to pre-convert objects to for use on a CUDA device.
-#
-# The resulting object type will be used as a starting point to determine the final
-# specialization and argument types (there might be other conversions, eg. factoring in the
-# ABI). This is different from `cconvert` in that we don't know which type to convert to.
-cudaconvert{T}(::Type{T}) = T
-
-cudaconvert{T}(::Type{DevicePtr{T}}) = Ptr{T}
-cudaconvert{T}(::Type{Ptr{T}})       = throw(InexactError())


### PR DESCRIPTION
Generated functions are fragile, and we were doing stuff we shouldn't (calling overloaded functions and calling its methods after the generated function was defined). This broke the package if precompilation was disabled, but even with precompilation enabled the generated function behind `@cuda` threw errors because during first inference-time execution `cudaconvert(DevicePtr{T})` wasn't defined. This also slowed down the kernel launch sequence.

Ref JuliaLang/julia#19942