### PR TITLE
Improve CuDeviceArray constructors.

### DIFF
--- a/src/device/intrinsics.jl
+++ b/src/device/intrinsics.jl
@@ -332,7 +332,7 @@ macro cuStaticSharedMem(typ, dims)
     return esc(:(CUDAnative.generate_static_shmem(Val{$id}, $typ, Val{$dims})))
 end
 
-function emit_static_shmem{N}(id::Integer, jltyp::Type, shape::NTuple{N,Int})
+function emit_static_shmem{N}(id::Integer, jltyp::Type, shape::NTuple{N,<:Integer})
     if !haskey(llvmtypes, jltyp)
         error("cuStaticSharedMem: unsupported type '$jltyp'")
     end

--- a/test/array.jl
+++ b/test/array.jl
@@ -3,14 +3,36 @@
 ############################################################################################
 
 @testset "constructors" begin
-    # Inner constructors
-    @on_device CuDeviceArray{Int,1}((1,), Ptr{Int}(C_NULL))
+    # inner constructors
+    let
+        p = Ptr{Int}(C_NULL)
+        @on_device CuDeviceArray{Int,1}((1,), $p)
+    end
 
-    # Outer constructors
-    @on_device CuDeviceArray{Int}(1, Ptr{Int}(C_NULL))
-    @on_device CuDeviceArray{Int}((1,), Ptr{Int}(C_NULL))
-    @on_device CuDeviceArray(1, Ptr{Int}(C_NULL))
-    @on_device CuDeviceArray((1,), Ptr{Int}(C_NULL))
+    # outer constructors
+    for I in [Int32,Int64]
+        a = I(1)
+        b = I(2)
+        p = Ptr{I}(C_NULL)
+
+        # not parameterized
+        @on_device CuDeviceArray($b, $p)
+        @on_device CuDeviceArray(($b,), $p)
+        @on_device CuDeviceArray(($b,$a), $p)
+
+        # partially parameterized
+        @on_device CuDeviceArray{$I}($b, $p)
+        @on_device CuDeviceArray{$I}(($b,), $p)
+        @on_device CuDeviceArray{$I}(($a,$b), $p)
+
+        # fully parameterized
+        @on_device CuDeviceArray{$I,1}($b, $p)
+        @on_device CuDeviceArray{$I,1}(($b,), $p)
+        @test_throws ErrorException @on_device CuDeviceArray{$I,1}(($a,$b), $p)
+        @test_throws ErrorException @on_device CuDeviceArray{$I,2}($b, $p)
+        @test_throws ErrorException @on_device CuDeviceArray{$I,2}(($b,), $p)
+        @on_device CuDeviceArray{$I,2}(($a,$b), $p)
+    end
 end
 
 
@@ -18,7 +40,6 @@ end
 ############################################################################################
 
 @testset "basics" begin     # argument passing, get and setindex, length
-
     dims = (16, 16)
     len = prod(dims)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,7 +29,7 @@ macro on_device(exprs)
     quote
         let
             @eval function $kernel_fn()
-                $exprs
+                $(esc(exprs))
 
                 return nothing
             end


### PR DESCRIPTION
- allow more styles of constructors (some typevars, all typevars, etc), mimicking Base.Array
- allow calling outer constructors with dims<:Integer
- improve tests
- docs

Also convert some unrelated methods to 0.6-style where.

cc @cfoket