### PR TITLE
WIP/RFHelp: kernel precompilation

### DIFF
--- a/examples/vadd.jl
+++ b/examples/vadd.jl
@@ -11,6 +11,9 @@ end
 dev = CuDevice(0)
 ctx = CuContext(dev)
 
+CUDAnative.precompile(kernel_vadd,
+                      (CuDeviceArray{Float32,2},CuDeviceArray{Float32,2},CuDeviceArray{Float32,2}))
+
 dims = (3,4)
 a = round.(rand(Float32, dims) * 100)
 b = round.(rand(Float32, dims) * 100)

--- a/src/execution.jl
+++ b/src/execution.jl
@@ -217,6 +217,99 @@ const func_cache = Dict{UInt, CuFunction}()
     end
 end
 
+# alternatively, users can explicitly precompile kernels
+if is_linux()
+    const func_cache_dir = joinpath(get(ENV, "XDG_CACHE_HOME", joinpath(homedir(), ".cache")),
+                                    "CUDAnative.jl")
+else
+    const func_cache_dir = joinpath(tempdir(), "CUDAnative.jl")
+end
+function precompile(func::ANY, types::ANY)
+    @assert typeof(types) <: Tuple
+    precomp_key = hash(tuple(typeof(func), types...))
+
+    # details about the code
+    meth = which(func, types)
+    source = String(meth.file)
+    line = meth.line
+
+    # details about the hardware
+    ctx = CuCurrentContext()
+    dev = device(ctx)
+    cap = capability(dev)
+
+    # generate a hash uniquely identifying this function instance
+    isdir(func_cache_dir) || mkpath(func_cache_dir)
+    cache_id = hash((meth.name, types, source, line))
+    cache_file = joinpath(func_cache_dir, "$(meth.name).$(cache_id).bin")
+
+    # as we cannot interface properly with the precompile logic, apply some heuristics
+    if Base.JLOptions().use_compilecache == 0
+        cache_valid = false
+    elseif isfile(cache_file)
+        cache_valid = true
+    else
+        info("Precompiling $func($(join(types, ", "))).")
+        cache_valid = false
+    end
+
+    # check some mtimes
+    if cache_valid
+        cache_mtime = stat(cache_file).mtime
+
+        # julia binary
+        julia = Base.julia_cmd().exec[1]
+        julia_mtime = stat(julia).mtime
+
+        # julia system image
+        sysimg = map(arg->arg[3:end],
+                     filter(arg->startswith(arg, "-J"),
+                            Base.julia_cmd().exec))[1]
+        sysimg_mtime = stat(julia).mtime
+
+        # source file containing function
+        source_mtime = stat(source).mtime
+
+        # packages
+        function package_mtime(package)
+            package_cache_file = joinpath(Base.LOAD_CACHE_PATH[1], "$package.ji")
+            isfile(package_cache_file) ? stat(package_cache_file).mtime : 0
+        end
+        packages_mtime = package_mtime.(["CUDAnative", "LLVM"])
+
+        if Base.max(julia_mtime, sysimg_mtime, source_mtime, packages_mtime...) > cache_mtime
+            info("Recompiling stale cache file $cache_file for $func($(join(types, ", "))).")
+            cache_valid = false
+        end
+    end
+
+    # compile & cache
+    if cache_valid
+        open(cache_file, "r") do f
+            module_asm = deserialize(f)
+            module_entry = deserialize(f)
+        end
+    else
+        (module_asm, module_entry) = cufunction_compile(cap, func, types)
+        open(cache_file, "w") do f
+            serialize(f, module_asm)
+            serialize(f, module_entry)
+        end
+    end
+
+    # insert into the function cache for at-cuda
+    # NOTE: this has to exactly match what at-cuda does
+    key = hash((precomp_key, ctx))
+    if (haskey(func_cache, key))
+        cuda_fun = func_cache[key]
+    else
+        cuda_fun, _ = cufunction(device(ctx), func, types)
+        func_cache[key] = cuda_fun
+    end
+
+    return cuda_fun
+end
+
 """
 Return the nearest number of threads that is a multiple of the warp size of a device:
 

--- a/src/jit.jl
+++ b/src/jit.jl
@@ -292,20 +292,25 @@ function check_kernel(func::ANY, tt::ANY)
 end
 
 # Main entry-point for compiling a Julia function + argtypes to a callable CUDA function
-function cufunction(dev::CuDevice, func::ANY, types::ANY)
+cufunction(dev::CuDevice, func, types) = cufunction(capability(dev), func, types)
+function cufunction(cap::VersionNumber, func::ANY, types::ANY)
+    (module_asm, module_entry) = cufunction_compile(cap, func, types)
+    (cuda_fun, cuda_mod) = cufunction_create(module_asm, module_entry)
+end
+function cufunction_compile(cap::VersionNumber, func::ANY, types::ANY)
     @assert isa(func, Core.Function)
     tt = Base.to_tuple_type(types)
     check_kernel(func, tt)
 
     # select a capability level
-    dev_cap = capability(dev)
-    compat_caps = filter(cap -> cap <= dev_cap, supported_capabilities)
+    compat_caps = filter(candidate_cap -> candidate_cap <= cap, supported_capabilities)
     isempty(compat_caps) &&
-        error("Device capability v$dev_cap not supported by available toolchain")
+        error("Device capability v$cap not supported by available toolchain")
     cap = maximum(compat_caps)
 
-    (module_asm, module_entry) = compile_function(func, tt, cap)
-
+    return compile_function(func, tt, cap)
+end
+function cufunction_create(module_asm::String, module_entry::String)
     # enable debug options based on Julia's debug setting
     jit_options = Dict{CUDAdrv.CUjit_option,Any}()
     if DEBUG || Base.JLOptions().debug_level >= 1
@@ -315,6 +320,7 @@ function cufunction(dev::CuDevice, func::ANY, types::ANY)
         # TODO: detect cuda-gdb
         jit_options[CUDAdrv.GENERATE_DEBUG_INFO] = true
     end
+
     cuda_mod = CuModule(module_asm, jit_options)
     cuda_fun = CuFunction(cuda_mod, module_entry)
 


### PR DESCRIPTION
In an attempt to speed up CUDAnative, I've implemented a precompile-like compile cache (opt-in). Turns out that doesn't really speed much up... Not sure how to proceed though.

What is the current way of speeding up package load times? I figured "SnoopCompile + precompile.jl", but that lists some really strange entries:

```

julia> SnoopCompile.@snoop "/tmp/vadd.csv" begin
       include("examples/vadd.jl")
       end
Launching new julia process to run commands...
done.

julia> data = SnoopCompile.read("/tmp/vadd.csv")

 13737776  …  "Base.Type(Type{Ref{Ptr{LLVM.API.LLVMOpaqueValue}}}, Array{Any, 1})"                                                                                                                                                                                                                                                                
 24132971     "Base.unsafe_convert(typeof(Base.unsafe_convert), Type{Ptr{Ptr{LLVM.API.LLVMOpaqueType}}}, Base.RefArray{Ptr{LLVM.API.LLVMOpaqueType}, Array{Ptr{LLVM.API.LLVMOpaqueType}, 1}, Any})"                                                                                                                                               
 37450972     "Base.Type(Type{Ref{Ptr{LLVM.API.LLVMOpaqueType}}}, Array{Any, 1})"                                                                                                                                                                                                                                                                 
 91889685  …  "Base.ht_keyindex(typeof(Base.ht_keyindex), Base.Dict{UInt32, Type{T} where T}, UInt32)" 
```

And as far as the documentation goes, we can't precompile functions in other modules (here, Base)?