### PR TITLE
DOA: Small event-based profiler.

### DIFF
--- a/src/CUDAnative.jl
+++ b/src/CUDAnative.jl
@@ -11,6 +11,7 @@ isfile(ext) || error("Unable to load $ext\n\nPlease run Pkg.build(\"CUDAnative\"
 include(ext)
 
 include("jit.jl")
+include("profile.jl")
 include("device/array.jl")
 include("device/intrinsics.jl") # these files contain generated functions,
 include("execution.jl")         # so should get loaded quite late (JuliaLang/julia#19942)

--- a/src/execution.jl
+++ b/src/execution.jl
@@ -129,7 +129,7 @@ function emit_allocations(args, codegen_types, call_types)
     return kernel_allocations, args
 end
 
-function emit_cudacall(func, dims, shmem, stream, types, args)
+function emit_cudacall(func, id, dims, shmem, stream, types, args)
     # TODO: can we handle non-isbits types?
     all(t -> isbits(t) && sizeof(t) > 0, types) ||
         error("can only pass bitstypes of size > 0 to CUDA kernels")
@@ -137,7 +137,9 @@ function emit_cudacall(func, dims, shmem, stream, types, args)
         error("cannot pass objects that don't fit in registers to CUDA functions")
 
     return quote
-        cudacall($func, $dims[1], $dims[2], $shmem, $stream, Tuple{$(types...)}, $(args...))
+        Profile.@instr_launch $id begin
+            cudacall($func, $dims[1], $dims[2], $shmem, $stream, Tuple{$(types...)}, $(args...))
+        end
     end
 end
 
@@ -206,7 +208,8 @@ const func_cache = Dict{UInt, CuFunction}()
     call_types = map(x->x[2], filter(x->x[1], zip(concrete, call_types)))
     arg_exprs  = map(x->x[2], filter(x->x[1], zip(concrete, arg_exprs)))
 
-    kernel_call = emit_cudacall(cuda_fun, :(dims), :(shmem), :(stream),
+    kernel_call = emit_cudacall(cuda_fun, func.name.mt.name,
+                                :(dims), :(shmem), :(stream),
                                 call_types, arg_exprs)
 
     quote

--- a/src/execution.jl
+++ b/src/execution.jl
@@ -137,7 +137,7 @@ function emit_cudacall(func, id, dims, shmem, stream, types, args)
         error("cannot pass objects that don't fit in registers to CUDA functions")
 
     return quote
-        Profile.@instr_launch $id begin
+        Profile.@instr_launch $id $stream begin
             cudacall($func, $dims[1], $dims[2], $shmem, $stream, Tuple{$(types...)}, $(args...))
         end
     end

--- a/src/profile.jl
+++ b/src/profile.jl
@@ -89,21 +89,21 @@ end
 
 ## instrumentation
 
-macro instr_launch(kernel, ex)
+macro instr_launch(kernel, stream, ex)
     quote
         # tic
         if enabled[]
             lnch = Launch()
             push!(launches, ($(QuoteNode(kernel)), lnch))
             nvprof_enabled[] && start_nvprof()
-            record(lnch.start)
+            record(lnch.start, $(esc(stream)))
         end
 
         $(esc(ex))
 
         # toc
         if enabled[]
-            record(lnch.stop)
+            record(lnch.stop, $(esc(stream)))
         end
     end
 end

--- a/src/profile.jl
+++ b/src/profile.jl
@@ -1,0 +1,149 @@
+export @profile
+
+"""
+    @profile
+
+`@profile <expression>` runs your expression, while activating the CUDAnative profiler
+measuring certain CUDA events like kernel launches. This information is saved in an global,
+internal buffer.
+"""
+macro profile(ex)
+    quote
+        Profile.enabled[] = true
+        $(esc(ex))
+        Profile.enabled[] = false
+        Profile.nvprof_enabled[] && Profile.stop_nvprof()
+    end
+end
+
+
+module Profile
+
+using CUDAdrv
+
+
+## control
+
+const enabled = Ref(false)
+
+const nvprof_enabled = Ref(false)
+const nvprof_started = Ref(false)
+
+"""
+    init(; nvprof::Bool)
+
+Configures how the CUDAnative profiler behaves. The keyword argument `nvprof` controls
+whether the profiler also activates the native CUDA profiler, upon first kernel launch, for
+use with `nvprof`.
+"""
+function init(; nvprof::Bool = false)
+    nvprof_enabled[] = nvprof
+end
+
+# lazy start the CUDA profiler, to get more compact traces in eg. nvvp
+function start_nvprof()
+    if !nvprof_started[]
+        nvprof_started[] = true
+        CUDAdrv.start_profiler()
+    end
+end
+
+function stop_nvprof()
+    if nvprof_started[]
+        CUDAdrv.stop_profiler()
+        nvprof_started[] = false
+    end
+end
+
+
+## state
+
+struct Launch
+    start::CuEvent
+    stop::CuEvent
+
+    Launch() = new(CuEvent(), CuEvent())
+end
+
+const kernel_launches = Dict{Symbol,Vector{Launch}}()
+
+"""
+    fetch() -> data
+
+Returns the contents of the internal buffer. This can be used for manual inspection, or to
+pass to `print`.
+"""
+function fetch()
+    return [kernel_launches]
+end
+
+"""
+    clear()
+
+Clear any existing data from the internal buffer.
+"""
+function clear()
+    empty!(kernels)
+end
+
+
+## instrumentation
+
+macro instr_launch(kernel, ex)
+    if !haskey(kernel_launches, kernel)
+        kernel_launches[kernel] = Launch[]
+    end
+
+    quote
+        # tic
+        if enabled[]
+            lnch = Launch()
+            push!(kernel_launches[$(QuoteNode(kernel))], lnch)
+            nvprof_enabled[] && start_nvprof()
+            record(lnch.start)
+        end
+
+        $(esc(ex))
+
+        # toc
+        if enabled[]
+            record(lnch.stop)
+        end
+    end
+end
+
+
+## reporting
+
+print() = print(STDOUT, fetch())
+
+"""
+    print([io::IO = STDOUT,] [data::Vector]; kwargs...)
+
+Prints profiling results to `io` (by default, `STDOUT`). If you do not supply a `data`
+argument, the default internal buffer will be used.
+
+The keyword arguments can be any combination of:
+
+ - `format` -- Determines how timings are printed. Possible values, :csv.
+"""
+function print(io, data, format=:csv)
+    (kernel_launches, ) = data
+    any(fmt->fmt == format, [:csv]) || error("Unknown format")
+
+    # header
+    if format == :csv
+        println(io, "kernel,time(μs)")
+    end
+
+    # data
+    for (kernel, launches) in kernel_launches, lnch in launches
+        synchronize(lnch.stop)
+
+        if format == :csv
+            println(io, "$kernel,$(1_000_000*elapsed(lnch.start, lnch.stop))")
+        end
+    end
+end
+
+end


### PR DESCRIPTION
Example usage;

```julia
using CUDAdrv, CUDAnative

function kernel_vadd(a, b, c)
    i = (blockIdx().x-1) * blockDim().x + threadIdx().x
    c[i] = a[i] + b[i]

    return nothing
end

const dev = CuDevice(0)
const ctx = CuContext(dev)

function main()
    dims = (3,4)
    a = round.(rand(Float32, dims) * 100)
    b = round.(rand(Float32, dims) * 100)

    d_a = CuArray(a)
    d_b = CuArray(b)
    d_c = similar(d_a)

    len = prod(dims)
    @cuda (1,len) kernel_vadd(d_a, d_b, d_c)
    Array(d_c)
end

# CUDAnative.Profile.init(nvprof=true)

CUDAnative.@profile begin
    main()
end

CUDAnative.Profile.print()

destroy(ctx)
```


cc @cfoket