### PR TITLE
Enable generation of FMA instructions.

### DIFF
--- a/src/CUDAnative.jl
+++ b/src/CUDAnative.jl
@@ -23,6 +23,7 @@ function __init__()
         VersionNumber(Base.libllvm_version) != julia_llvm_version
         error("Your set-up has changed. Please re-run Pkg.build(\"CUDAnative\") and restart Julia.")
     end
+    init_jit()
 end
 
 end

--- a/src/jit.jl
+++ b/src/jit.jl
@@ -305,3 +305,14 @@ function cufunction(dev::CuDevice, func::ANY, types::ANY)
 
     return cuda_fun, cuda_mod
 end
+
+function init_jit()
+    llvm_args = [
+        # Program name; can be left blank.
+        "",
+        # Enable generation of FMA instructions to mimic behavior of nvcc.
+        "--nvptx-fma-level=1",
+    ]
+    LLVM.API.LLVMParseCommandLineOptions(Int32(length(llvm_args)),
+        [Base.unsafe_convert(Cstring, llvm_arg) for llvm_arg in llvm_args], C_NULL)
+end


### PR DESCRIPTION
This patch passes `--nvptx-fma-level=1` to LLVM's NVPTX backend to mimic the default behavior of `nvcc` with respect to the generation of FMA instructions. Note that `nvcc`'s `--fmad` option defaults to `true`.