### PR TITLE
make minimum julia version 0.6.0-pre

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.6-
+julia 0.6.0-pre
 CUDAdrv 0.3
 LLVM 0.2


### PR DESCRIPTION
at least since the new type syntax has been used, the package wouldn't work
on early 0.6.0-dev versions so shouldn't claim to support them any more