### PR TITLE
Use a value sink to prevent noinline functions from getting optimized away.

### DIFF
--- a/test/base.jl
+++ b/test/base.jl
@@ -5,7 +5,7 @@
 @testset "method caching" begin
 
 # #17057 fallout
-@eval @noinline post17057_child(i) = i+1
+@eval @noinline post17057_child(i) = sink(i)
 @eval function post17057_parent(arr::Ptr{Int64})
     i = post17057_child(0)
     unsafe_store!(arr, i, i)

--- a/test/execution.jl
+++ b/test/execution.jl
@@ -106,7 +106,7 @@ end
 
 
 @testset "calling device function" begin
-    @eval @noinline exec_devfun_child(i) = return i+1
+    @eval @noinline exec_devfun_child(i) = sink(i)
     @eval exec_devfun_parent() = (exec_devfun_child(1); return nothing)
 
     @cuda (1,1) exec_devfun_parent()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -40,6 +40,18 @@ macro on_device(exprs)
     end
 end
 
+# helper function for sinking a value to prevent the callee from getting optimized away
+@inline sink(i::Int32) =
+    Base.llvmcall("""%slot = alloca i32
+                     store volatile i32 %0, i32* %slot
+                     %value = load volatile i32, i32* %slot
+                     ret i32 %value""", Int32, Tuple{Int32}, i)
+@inline sink(i::Int64) =
+    Base.llvmcall("""%slot = alloca i64
+                     store volatile i64 %0, i64* %slot
+                     %value = load volatile i64, i64* %slot
+                     ret i64 %value""", Int64, Tuple{Int64}, i)
+
 @testset "CUDAnative" begin
 
 @test devcount() > 0


### PR DESCRIPTION
Hopefully fixes #53. cc @keno @vchuravy 