### PR TITLE
Automatic recompilation of dependent kernels.

### DIFF
--- a/src/jit.jl
+++ b/src/jit.jl
@@ -238,8 +238,8 @@ end
 # The `kernel` argument indicates whether we are compiling a kernel entry-point function,
 # in which case extra metadata needs to be attached.
 function compile_function(func::ANY, tt::ANY, cap::VersionNumber; kernel::Bool=true)
-    sig = """$func($(join(tt.parameters, ", ")))"""
-    debug("Compiling $sig for capability level $cap")
+    sig = "$(typeof(func).name.mt.name)($(join(tt.parameters, ", ")))"
+    debug("(Re)compiling kernel $sig for device capability $cap")
 
     # generate LLVM IR
     mod, entry = irgen(func, tt)
@@ -259,7 +259,7 @@ end
 
 # check whether a (function, tuple of types) yields a valid kernel method
 function check_kernel(func::ANY, tt::ANY)
-    sig = """$func($(join(tt.parameters, ", ")))"""
+    sig = "$(typeof(func).name.mt.name)($(join(tt.parameters, ", ")))"
 
     ml = Base.methods(func, tt)
     if length(ml) == 0

--- a/test/execution.jl
+++ b/test/execution.jl
@@ -253,6 +253,21 @@ end
     @test Array(A) == Float32[imag(x)]
 end
 
+
+@testset "automatic recompilation" begin
+    d_a = CuArray{Int}(1)
+
+    @eval exec_265(a) = (a[1]=1; return nothing)
+
+    @cuda (1,1) exec_265(d_a)
+    @test Array(d_a) == [1]
+
+    @eval exec_265(a) = (a[1]=2; return nothing)
+
+    @cuda (1,1) exec_265(d_a)
+    @test Array(d_a) == [2]
+end
+
 end
 
 ############################################################################################


### PR DESCRIPTION
```
   _       _ _(_)_     |  A fresh approach to technical computing
  (_)     | (_) (_)    |  Documentation: https://docs.julialang.org
   _ _   _| |_  __ _   |  Type "?help" for help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 0.6.0-rc2.0 (2017-05-18 02:31 UTC)
 _/ |\__'_|_|_|\__'_|  |  
|__/                   |  x86_64-unknown-linux-gnu

julia> using CUDAdrv, CUDAnative

julia> dev = CuDevice(0)
CUDAdrv.CuDevice(0, 0)

julia> ctx = CuContext(dev)
CUDAdrv.CuContext(Ptr{Void} @0x0000000000fa9520, true, true)

julia> foo() = @cuprintf("old")
foo (generic function with 1 method)

julia> @cuda (1,1) foo(); synchronize()
old

julia> foo() = @cuprintf("new")
foo (generic function with 1 method)

julia> @cuda (1,1) foo(); synchronize()
new
```

Needs test. Better way would be to have an inferable `const age = current_method_age` and introduce a function barrier, but this is better than nothing.