### PR TITLE
Use a default, global context for the first device.

### DIFF
--- a/docs/src/man/usage.md
+++ b/docs/src/man/usage.md
@@ -24,10 +24,6 @@ Using the `@cuda` macro, you can launch the kernel on a GPU of your choice:
 using CUDAdrv, CUDAnative
 using Base.Test
 
-# CUDAdrv functionality: select device, create context
-dev = CuDevice(0)
-ctx = CuContext(dev)
-
 # CUDAdrv functionality: generate and upload data
 a = round.(rand(Float32, (3, 4)) * 100)
 b = round.(rand(Float32, (3, 4)) * 100)
@@ -44,8 +40,19 @@ d_c = similar(d_a)  # output array
 c = Array(d_c)
 
 @test a+b ≈ c
+```
 
-destroy(ctx)
+This code is executed in a default, global context for the first device in your system. The
+compiler queries the context through `CuCurrentContext`, which implies you can easily switch
+contexts (using a different device, or supplying different flags) by activating a different
+one:
+
+```julia
+dev = CuDevice(0)
+CuContext(dev) do ctx
+    # allocate things in this context
+    @cuda ...
+end
 ```
 
 

--- a/examples/hello_world.jl
+++ b/examples/hello_world.jl
@@ -5,11 +5,5 @@ function hello_world()
     return
 end
 
-dev = CuDevice(0)
-ctx = CuContext(dev)
-
 @cuda (2,2) hello_world()
-
 synchronize()
-
-destroy!(ctx)

--- a/examples/oob.jl
+++ b/examples/oob.jl
@@ -8,9 +8,6 @@
 
 using CUDAdrv, CUDAnative
 
-dev = CuDevice(0)
-ctx = CuContext(dev)
-
 a = CuArray{Float32}(10)
 
 function memset(a, val)
@@ -20,7 +17,4 @@ function memset(a, val)
 end
 
 @cuda (1,11) memset(a, 0f0)
-
 synchronize()
-
-destroy!(ctx)

--- a/examples/pairwise.jl
+++ b/examples/pairwise.jl
@@ -108,9 +108,6 @@ function pairwise_dist_gpu(lat::Vector{Float32}, lon::Vector{Float32})
 end
 
 
-const dev = CuDevice(0)
-const ctx = CuContext(dev)
-
 # generate reasonable data
 const n = 10000
 const lat = rand(Float32, n) .* 45
@@ -118,5 +115,3 @@ const lon = rand(Float32, n) .* -120
 
 using Base.Test
 @test pairwise_dist_cpu(lat, lon) ≈ pairwise_dist_gpu(lat, lon)
-
-destroy!(ctx)

--- a/examples/reduce/benchmark.jl
+++ b/examples/reduce/benchmark.jl
@@ -4,7 +4,8 @@
 using BenchmarkTools
 include("reduce.jl")
 
-dev = CuDevice(0)
+ctx = CuCurrentContext()
+dev = device(ctx)
 @assert(capability(dev) >= v"3.0", "this example requires a newer GPU")
 
 len = 10^7
@@ -21,7 +22,6 @@ open(joinpath(@__DIR__, "reduce.jl.ptx"), "w") do f
                         cap=v"6.1.0")
 end
 
-ctx = CuContext(dev)
 benchmark_gpu = @benchmarkable begin
         gpu_reduce(+, gpu_input, gpu_output)
         val = Array(gpu_output)[1]
@@ -35,7 +35,6 @@ benchmark_gpu = @benchmarkable begin
         gc()
     )
 println(run(benchmark_gpu))
-destroy!(ctx)
 
 
 ## CUDA

--- a/examples/reduce/verify.jl
+++ b/examples/reduce/verify.jl
@@ -1,7 +1,8 @@
 using Base.Test
 include("reduce.jl")
 
-dev = CuDevice(0)
+ctx = CuCurrentContext()
+dev = device(ctx)
 if capability(dev) < v"3.0"
     warn("this example requires a newer GPU")
     exit(0)
@@ -15,11 +16,9 @@ cpu_val = reduce(+, input)
 
 # CUDAnative
 let
-    ctx = CuContext(dev)
     gpu_input = CuArray(input)
     gpu_output = similar(gpu_input)
     gpu_reduce(+, gpu_input, gpu_output)
     gpu_val = Array(gpu_output)[1]
-    destroy!(ctx)
     @assert cpu_val == gpu_val
 end

--- a/examples/scan.jl
+++ b/examples/scan.jl
@@ -58,9 +58,6 @@ function gpu_accumulate!(op::Function, data::CuDeviceMatrix{T}) where {T}
     return
 end
 
-dev = CuDevice(0)
-ctx = CuContext(dev)
-
 rows = 5
 cols = 4
 
@@ -74,8 +71,6 @@ gpu_a = CuArray(a)
 
 using Base.Test
 @test cpu_a ≈ Array(gpu_a)
-
-destroy!(ctx)
 
 
 # FURTHER IMPROVEMENTS:

--- a/examples/vadd.jl
+++ b/examples/vadd.jl
@@ -8,9 +8,6 @@ function kernel_vadd(a, b, c)
     return nothing
 end
 
-dev = CuDevice(0)
-ctx = CuContext(dev)
-
 dims = (3,4)
 a = round.(rand(Float32, dims) * 100)
 b = round.(rand(Float32, dims) * 100)
@@ -23,5 +20,3 @@ len = prod(dims)
 @cuda (1,len) kernel_vadd(d_a, d_b, d_c)
 c = Array(d_c)
 @test a+b ≈ c
-
-destroy!(ctx)

--- a/test/perf/launch_overhead/cuda.jl
+++ b/test/perf/launch_overhead/cuda.jl
@@ -10,9 +10,6 @@ const ITERATIONS = 5000
 # TODO: api-trace shows some attribute fetches, where do they come from?
 
 function main()    
-    dev = CuDevice(0)
-    ctx = CuContext(dev)
-
     mod = CuModuleFile("cuda.ptx")
     fun = CuFunction(mod, "kernel_dummy")
 
@@ -39,8 +36,6 @@ function main()
 
     @printf("CPU time: %.2fus\n", median(cpu_time))
     @printf("GPU time: %.2fus\n", median(gpu_time))
-
-    destroy!(ctx)
 end
 
 main()

--- a/test/perf/launch_overhead/cudanative.jl
+++ b/test/perf/launch_overhead/cudanative.jl
@@ -13,9 +13,6 @@ const len = 1000
 const ITERATIONS = 5000
 
 function main()    
-    dev = CuDevice(0)
-    ctx = CuContext(dev)
-
     cpu_time = Vector{Float64}(ITERATIONS)
     gpu_time = Vector{Float64}(ITERATIONS)
 
@@ -38,8 +35,6 @@ function main()
 
     @printf("CPU time: %.2fus\n", median(cpu_time))
     @printf("GPU time: %.2fus\n", median(gpu_time))
-
-    destroy!(ctx)
 end
 
 main()

--- a/test/perf/launch_overhead/cudanative_profile.jl
+++ b/test/perf/launch_overhead/cudanative_profile.jl
@@ -14,9 +14,6 @@ const len = 1000
 const ITERATIONS = 5000
 
 function main()    
-    dev = CuDevice(0)
-    ctx = CuContext(dev)
-
     cpu_time = Vector{Float64}(ITERATIONS)
 
     gpu_arr = CuArray{Float32}(len)
@@ -35,8 +32,6 @@ function main()
 
     @printf("CPU time: %.2fus\n", median(cpu_time))
     CUDAnative.Profile.print()
-
-    destroy!(ctx)
 end
 
 main()


### PR DESCRIPTION
Simplifies code quite a bit. Mimics what CUDA does.

Maybe we should tie into the primary context business though, but then everyone's GC/refcount logic has to be aware of one another for it to work properly. Didn't really feel like doing that today. People should just use explicit contexts if they want to have control over resources, I guess.