### PR TITLE
Use kernel wrapper functions to improve argument passing

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
 julia 0.6
 CUDAdrv 0.4.2
-LLVM 0.3.5
+LLVM 0.3.6

--- a/docs/src/man/performance.md
+++ b/docs/src/man/performance.md
@@ -1,33 +1,3 @@
 # Performance
 
-## Object arguments
-
-When passing a rich object like a `CuArray` to a GPU kernel, there's a memory allocation and
-copy happening behind the scenes. This means that every kernel call is synchronizing, which
-can easily kill performance in the case of fine-grained kernels.
-
-Although this issue will probably get fixed in the future, a workaround for now is to ensure
-all arguments are `bitstype` (ie. declared as primitive `bitstype` types, not to be confused
-with the `isbits` property). Specific to arrays, you can access and pass the underlying
-device pointer by means of the `ptr` field of `CuArray` objects, in addition to the size of
-the array:
-
-```julia
-function inc_slow(a)
-    a[threadIdx().x] += 1
-
-    return nothing
-end
-
-@cuda (1,3) inc_slow(d_a)                       # implicit alloc & memcpy
-
-
-function inc_fast(a_ptr, a_len)
-    a = CuDeviceArray(a_len, a_ptr)
-    a[threadIdx().x] += 1
-
-    return nothing
-end
-
-@cuda (1,3) inc_fast(pointer(d_a), length(d_a)) # no implicit memory ops
-```
+WIP.

--- a/src/execution.jl
+++ b/src/execution.jl
@@ -85,11 +85,11 @@ function actual_types(argtype::DataType)
         # pointerfree objects with a layout can be used on the GPU
         cgtype = argtype
         # but the ABI might require them to be passed by pointer
-        if isbitstype(argtype)
+        # if isbitstype(argtype)
             calltype = argtype
-        else
-            calltype = Ptr{argtype}
-        end
+        # else
+        #     calltype = Ptr{argtype}
+        # end
     else
         error("don't know how to handle argument of type $argtype")
     end
@@ -129,8 +129,8 @@ function emit_cudacall(func, dims, shmem, stream, types, args)
     # TODO: can we handle non-isbits types?
     all(t -> isbits(t) && sizeof(t) > 0, types) ||
         error("can only pass bitstypes of size > 0 to CUDA kernels")
-    any(t -> sizeof(t) > 8, types) &&
-        error("cannot pass objects that don't fit in registers to CUDA functions")
+    # any(t -> sizeof(t) > 8, types) &&
+    #     error("cannot pass objects that don't fit in registers to CUDA functions")
 
     return quote
         Profile.@launch begin

--- a/src/execution.jl
+++ b/src/execution.jl
@@ -11,9 +11,8 @@ using Base.Iterators: filter
 
 # Determine which type to pre-convert objects to for use on a CUDA device.
 #
-# The resulting object type will be used as a starting point to determine the final
-# specialization and argument types (there might be other conversions, eg. factoring in the
-# ABI). This is different from `cconvert` in that we don't know which type to convert to.
+# The resulting object type will be used as a starting point to determine the final argument
+# types. This is different from `cconvert` in that we don't know which type to convert to.
 function convert_type(t)
     # NOTE: this conversion was originally intended to be a user-extensible interface,
     #       a la cconvert (look for cudaconvert in f1e592e61d6898869b918331e3e625292f4c8cab).
@@ -38,7 +37,7 @@ function convert_type(t)
 end
 
 # Convert the arguments to a kernel function to their CUDA representation, and figure out
-# what types to specialize the kernel function for and how to actually pass those objects.
+# what types to specialize the kernel function for.
 function convert_arguments(args, types)
     argtypes = DataType[types...]
     argexprs = Union{Expr,Symbol}[args...]
@@ -57,80 +56,21 @@ function convert_arguments(args, types)
         end
     end
 
-    # figure out how to codegen and pass these types
-    codegen_types, call_types = Array{DataType}(length(argtypes)), Array{Type}(length(argtypes))
-    for i in 1:length(argexprs)
-        codegen_types[i], call_types[i] = actual_types(argtypes[i])
-    end
-
     # NOTE: DevicePtr's should have disappeared after this point
 
-    return argexprs, (codegen_types...), (call_types...)
-end
-
-# NOTE: keep this in sync with jl_is_bitstype in julia.h
-isbitstype(dt::DataType) =
-    !dt.mutable && dt.layout != C_NULL && nfields(dt) == 0 && sizeof(dt) > 0
-
-# Determine the actual types of an object, that is, 1) the type that needs to be used to
-# specialize (compile) the kernel function, and 2) the type which an object needs to be
-# converted to before passing it to a kernel.
-#
-# These two types can differ, eg. when passing a bitstype that doesn't fit in a register, in
-# which case we'll be specializing a function that directly uses that bitstype (and the
-# codegen ABI will figure out it needs to be passed by ref, ie. a pointer), but we do need to
-# allocate memory and pass an actual pointer since we perform the call ourselves.
-function actual_types(argtype::DataType)
-    if argtype.layout != C_NULL && Base.datatype_pointerfree(argtype)
-        # pointerfree objects with a layout can be used on the GPU
-        cgtype = argtype
-        # but the ABI might require them to be passed by pointer
-        # if isbitstype(argtype)
-            calltype = argtype
-        # else
-        #     calltype = Ptr{argtype}
-        # end
-    else
-        error("don't know how to handle argument of type $argtype")
-    end
-
-    # special-case args which don't appear in the generated code
-    # (but we still need to specialize for)
-    if !argtype.mutable && sizeof(argtype) == 0
-        # ghost type, ignored by the compiler
-        calltype = Base.Bottom
-    end
-
-    return cgtype::Type, calltype::Type
-end
-
-
-function emit_allocations(args, codegen_types, call_types)
-    # if we're generating code for a given type, but passing a pointer to that type instead,
-    # this is indicative of needing to upload the value to GPU memory
-    kernel_allocations = Expr(:block)
-    for i in 1:length(args)
-        if call_types[i] == Ptr{codegen_types[i]}
-            @gensym dev_arg
-            alloc = quote
-                $dev_arg = Mem.alloc($(codegen_types[i]))
-                # TODO: we're never freeing this (use refcounted single-value array?)
-                Mem.upload($dev_arg, $(args[i]))
-            end
-            append!(kernel_allocations.args, alloc.args)
-            args[i] = dev_arg
+    for argtype in argtypes
+        if argtype.layout == C_NULL || !Base.datatype_pointerfree(argtype)
+            error("don't know how to handle argument of type $argtype")
         end
     end
 
-    return kernel_allocations, args
+    return argexprs, argtypes
 end
 
 function emit_cudacall(func, dims, shmem, stream, types, args)
     # TODO: can we handle non-isbits types?
     all(t -> isbits(t) && sizeof(t) > 0, types) ||
         error("can only pass bitstypes of size > 0 to CUDA kernels")
-    # any(t -> sizeof(t) > 8, types) &&
-    #     error("cannot pass objects that don't fit in registers to CUDA functions")
 
     return quote
         Profile.@launch begin
@@ -140,6 +80,8 @@ function emit_cudacall(func, dims, shmem, stream, types, args)
 end
 
 world_age() = ccall(:jl_get_tls_world_age, UInt, ())
+
+isghosttype(dt) = !dt.mutable && sizeof(dt) == 0
 
 
 #
@@ -183,9 +125,7 @@ const compilecache = Dict{UInt, CuFunction}()
 @generated function generated_cuda{F<:Core.Function,N}(dims::Tuple{CuDim, CuDim}, shmem, stream,
                                                        func::F, args::Vararg{Any,N})
     arg_exprs = [:( args[$i] ) for i in 1:N]
-    arg_exprs, codegen_types, call_types = convert_arguments(arg_exprs, args)
-
-    kernel_allocations, arg_exprs = emit_allocations(arg_exprs, codegen_types, call_types)
+    arg_exprs, arg_types = convert_arguments(arg_exprs, args)
 
     # compile the function, if necessary
     # TODO: we currently recompile if _any_ world change is detected.
@@ -193,29 +133,28 @@ const compilecache = Dict{UInt, CuFunction}()
     #       query the kernel method's age, and/or put that query in a wrapper method with a
     #       back-edge from the kernel method to make the check completely free.
     @gensym cuda_fun
-    precomp_key = hash(tuple(func, codegen_types...))  # precomputable part of the key
+    precomp_key = hash(tuple(func, arg_types...))  # precomputable part of the key
     kernel_compilation = quote
         ctx = CuCurrentContext()
         key = hash(($precomp_key, ctx, world_age()))
         if (haskey(compilecache, key))
             $cuda_fun = compilecache[key]
         else
-            $cuda_fun, _ = cufunction(device(ctx), func, $codegen_types)
+            $cuda_fun, _ = cufunction(device(ctx), func, $arg_types)
             compilecache[key] = $cuda_fun
         end
     end
 
     # filter out non-concrete args
-    concrete = map(t->t!=Base.Bottom, call_types)
-    call_types = map(x->x[2], filter(x->x[1], zip(concrete, call_types)))
-    arg_exprs  = map(x->x[2], filter(x->x[1], zip(concrete, arg_exprs)))
+    concrete = map(t->!isghosttype(t), arg_types)
+    arg_types = map(x->x[2], filter(x->x[1], zip(concrete, arg_types)))
+    arg_exprs = map(x->x[2], filter(x->x[1], zip(concrete, arg_exprs)))
 
     kernel_call = emit_cudacall(cuda_fun, :(dims), :(shmem), :(stream),
-                                call_types, arg_exprs)
+                                arg_types, arg_exprs)
 
     quote
         Base.@_inline_meta
-        $kernel_allocations
         $kernel_compilation
         $kernel_call
     end

--- a/src/jit.jl
+++ b/src/jit.jl
@@ -236,11 +236,9 @@ function link_libdevice!(mod::LLVM.Module, cap::VersionNumber)
         push!(metadata(mod), "nvvm-reflect-ftz",
               MDNode([ConstantInt(Int32(1))]))
 
-        # FIXME: we shouldn't queue this manually,
-        #        but use the TM's `addEarlyAsPossiblePasses` instead
-
         # 6. Run standard optimization pipeline
-        always_inliner!(pm)
+        #
+        #    see `optimize!`
 
         run!(pm, mod)
     end

--- a/src/jit.jl
+++ b/src/jit.jl
@@ -181,8 +181,8 @@ function irgen(func::ANY, tt::ANY; kernel::Bool=false)
             ret!(builder)
         end
 
-        # TODO: remove old function
         push!(function_attributes(entry_f), EnumAttribute("alwaysinline"))
+        linkage!(entry_f, LLVM.API.LLVMInternalLinkage)
         entry_f = wrapper_f
     end
         

--- a/src/jit.jl
+++ b/src/jit.jl
@@ -44,7 +44,7 @@ function raise_exception(insblock::BasicBlock, ex::Value)
     call!(builder, trap)
 end
 
-function irgen(func::ANY, tt::ANY)
+function irgen(func::ANY, tt::ANY; kernel::Bool=false)
     # sanity checks
     Base.JLOptions().can_inline == 0 &&
         Base.warn_once("inlining disabled, CUDA code generation will almost certainly fail")
@@ -92,6 +92,7 @@ function irgen(func::ANY, tt::ANY)
 
         isnull(entry_fn) && error("could not find entry-point function (got ", join(LLVM.name.(collect(functions(entry_mod))), ", ", " and "), ")")
     end
+    entry_fn = get(entry_fn)
 
     # link all the modules
     for irmod in irmods
@@ -122,17 +123,91 @@ function irgen(func::ANY, tt::ANY)
                     LLVM.name!(f, safe_fn)
 
                     # take care if we're renaming the entry-point function
-                    if orig_fn == get(entry_fn)
-                        entry_fn = Nullable(safe_fn)
+                    if orig_fn == entry_fn
+                        entry_fn = safe_fn
                     end
                 end
             end
         end
     end
+
+    # generate a wrapper to fix the kernel calling convention
+    entry_f = get(functions(mod), entry_fn)
+    if kernel
+        entry_ft = eltype(llvmtype(entry_f))
+        @assert return_type(entry_ft) == LLVM.VoidType()
+        function wrapper_type(julia_t, codegen_t)
+            if isa(codegen_t, LLVM.PointerType) && !isa(julia_t, Ptr)
+                # we didn't specify a pointer, but codegen passes one anyway.
+                # make the wrapper accept a value type instead.
+                return equally_sized_type(julia_t)
+            else
+                return codegen_t
+            end
+        end
+        function equally_sized_type(t)
+            # we don't want to bother lowering Julia types to their exact LLVM counterpart,
+            # so just lower to an equally-sized type consisting of a bunch of integers.
+            sz = Core.sizeof(t)
+            if sz % 8 == 0
+                typ = LLVM.Int64Type()
+                num = sz ÷ 8
+            elseif sz % 4 == 0
+                typ = LLVM.Int32Type()
+                num = sz ÷ 4
+            elseif sz % 2 == 0
+                typ = LLVM.Int16Type()
+                num = sz ÷ 2
+            else
+                typ = LLVM.Int8Type()
+                num = sz
+            end
+            return LLVM.ArrayType(typ, num)
+        end
+        wrapper_types = LLVM.LLVMType[wrapper_type(julia_t, codegen_t)
+                                      for (julia_t, codegen_t)
+                                      in zip(tt.parameters, parameters(entry_ft))]
+        wrapper_fn = "ptxcall" * entry_fn[6:end]
+        wrapper_ft = LLVM.FunctionType(LLVM.VoidType(), wrapper_types)
+        wrapper_f = LLVM.Function(mod, wrapper_fn, wrapper_ft)
+        Builder() do builder
+            entry = BasicBlock(wrapper_f, "entry")
+            position!(builder, entry)
+
+            wrapper_args = Vector{LLVM.Value}()
+
+            # perform argument conversions
+            codegen_types = parameters(entry_ft)
+            wrapper_params = parameters(wrapper_f)
+            for (julia_t, codegen_t, wrapper_t, wrapper_param) in
+                zip(tt.parameters, codegen_types, wrapper_types, wrapper_params)
+                if codegen_t != wrapper_t
+                    # the wrapper argument doesn't match the kernel parameter type.
+                    # this only happens when codegen wants to pass a pointer.
+                    @assert isa(codegen_t, LLVM.PointerType)
+                    # copy the argument value to a stack slot, and reference it.
+                    ptr = alloca!(builder, wrapper_t)
+                    store!(builder, wrapper_param, ptr)
+                    ptr_compat = bitcast!(builder, ptr, codegen_t)
+                    push!(wrapper_args, ptr_compat)
+                else
+                    push!(wrapper_args, wrapper_param)
+                end
+            end
+
+            call!(builder, entry_f, wrapper_args)
+
+            ret!(builder)
+        end
+
+        # TODO: remove old function
+        push!(function_attributes(entry_f), EnumAttribute("alwaysinline"))
+        entry_f = wrapper_f
+    end
         
     verify(mod)
 
-    return mod, get(functions(mod), get(entry_fn))
+    return mod, entry_f
 end
 
 const libdevices = Dict{VersionNumber, LLVM.Module}()
@@ -245,7 +320,7 @@ function compile_function(func::ANY, tt::ANY, cap::VersionNumber; kernel::Bool=t
     debug("(Re)compiling kernel $sig for device capability $cap")
 
     # generate LLVM IR
-    mod, entry = irgen(func, tt)
+    mod, entry = irgen(func, tt; kernel=kernel)
     trace("Module entry point: ", LLVM.name(entry))
 
     # link libdevice, if it might be necessary

--- a/src/jit.jl
+++ b/src/jit.jl
@@ -140,29 +140,10 @@ function irgen(func::ANY, tt::ANY; kernel::Bool=false)
             if isa(codegen_t, LLVM.PointerType) && !isa(julia_t, Ptr)
                 # we didn't specify a pointer, but codegen passes one anyway.
                 # make the wrapper accept a value type instead.
-                return equally_sized_type(julia_t)
+                return eltype(codegen_t)
             else
                 return codegen_t
             end
-        end
-        function equally_sized_type(t)
-            # we don't want to bother lowering Julia types to their exact LLVM counterpart,
-            # so just lower to an equally-sized type consisting of a bunch of integers.
-            sz = Core.sizeof(t)
-            if sz % 8 == 0
-                typ = LLVM.Int64Type()
-                num = sz ÷ 8
-            elseif sz % 4 == 0
-                typ = LLVM.Int32Type()
-                num = sz ÷ 4
-            elseif sz % 2 == 0
-                typ = LLVM.Int16Type()
-                num = sz ÷ 2
-            else
-                typ = LLVM.Int8Type()
-                num = sz
-            end
-            return LLVM.ArrayType(typ, num)
         end
         wrapper_types = LLVM.LLVMType[wrapper_type(julia_t, codegen_t)
                                       for (julia_t, codegen_t)

--- a/src/jit.jl
+++ b/src/jit.jl
@@ -138,7 +138,7 @@ function irgen(func::ANY, tt::ANY; kernel::Bool=false)
         @assert return_type(entry_ft) == LLVM.VoidType()
 
         # filter out ghost types, which don't occur in the LLVM function signatures
-        julia_types = filter(t->t.mutable || sizeof(t) > 0, tt.parameters)
+        julia_types = filter(dt->!isghosttype(dt), tt.parameters)
 
         # generate the wrapper function type & def
         function wrapper_type(julia_t, codegen_t)

--- a/src/jit.jl
+++ b/src/jit.jl
@@ -139,7 +139,10 @@ function irgen(func::ANY, tt::ANY; kernel::Bool=false)
 
         # generate the wrapper function type & def
         function wrapper_type(julia_t, codegen_t)
-            if isa(codegen_t, LLVM.PointerType) && !(julia_t <: Ptr)
+            if !julia_t.mutable && sizeof(julia_t) == 0
+                # ghost type, ignored by the compiler
+                return codegen_t
+            elseif isa(codegen_t, LLVM.PointerType) && !(julia_t <: Ptr)
                 # we didn't specify a pointer, but codegen passes one anyway.
                 # make the wrapper accept the underlying value instead.
                 return eltype(codegen_t)

--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -34,9 +34,10 @@ for defaults to the current active device's capability, or v"2.0" if there is no
 context.
 """
 function code_llvm(io::IO, func::ANY, types::ANY=Tuple;
-                   optimize::Bool=true, dump_module::Bool=false,
+                   optimize::Bool=true, dump_module::Bool=true,
                    cap::VersionNumber=current_capability())
-    mod, entry = irgen(func, types)
+    tt = Base.to_tuple_type(types)
+    mod, entry = irgen(func, tt)
     if optimize
         optimize!(mod, cap)
     end
@@ -130,6 +131,7 @@ for fname in [:code_lowered, :code_typed, :code_warntype, :code_llvm, :code_ptx,
         """ macro $(fname)(ex0)
             if ex0.head == :macrocall
                 # @cuda (...) f()
+                # TODO: pass kernel=true to irgen here
                 if Base.VERSION >= v"0.7.0-DEV.357"
                     ex0 = ex0.args[4]
                 else

--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -34,10 +34,10 @@ for defaults to the current active device's capability, or v"2.0" if there is no
 context.
 """
 function code_llvm(io::IO, func::ANY, types::ANY=Tuple;
-                   optimize::Bool=true, dump_module::Bool=true,
-                   cap::VersionNumber=current_capability())
+                   optimize::Bool=true, dump_module::Bool=false,
+                   cap::VersionNumber=current_capability(), kernel::Bool=false)
     tt = Base.to_tuple_type(types)
-    mod, entry = irgen(func, tt)
+    mod, entry = irgen(func, tt; kernel=kernel)
     if optimize
         optimize!(mod, cap)
     end

--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -109,40 +109,66 @@ code_sass(func::ANY, types::ANY=Tuple; kwargs...) = code_sass(STDOUT, func, type
 # @code_* replacements
 #
 
-for fname in [:code_lowered, :code_typed, :code_warntype, :code_llvm, :code_ptx, :code_sass]
+for (fname,kernel_arg) in [(:code_lowered, false), (:code_typed, false), (:code_warntype, false),
+                           (:code_llvm, true), (:code_ptx, true), (:code_sass, false)]
     # types often need to be converted (eg. CuArray -> CuDeviceArray),
     # so generate a type-converting wrapper, and a macro to call it
     fname_wrapper = Symbol(fname, :_cputyped)
+    if kernel_arg
+        # some reflection functions take a `kernel` argument, indicating whether
+        # kernel function or device function conventions should be used
+        @eval begin
+            function $fname_wrapper(func, types, kernel::Bool)
+                _, arg_types =
+                    convert_arguments(fill(Symbol(), length(types.parameters)),
+                                      types.parameters)
+                $fname(func, arg_types; kernel=kernel)
+            end
+        end
+    else
+        @eval begin
+            function $fname_wrapper(func, types)
+                _, arg_types =
+                    convert_arguments(fill(Symbol(), length(types.parameters)),
+                                      types.parameters)
+                $fname(func, arg_types)
+            end
+        end
+    end
+
+    # TODO: test the kernel_arg-based behavior
 
     @eval begin
-        function $fname_wrapper(func, types)
-            _, arg_types =
-                convert_arguments(fill(Symbol(), length(types.parameters)),
-                                  types.parameters)
-            $fname(func, arg_types)
-        end
-
         @doc $"""
             $fname
 
         Extracts the relevant function call from any `@cuda` invocation, evaluates the
         arguments to the function or macro call, determines their types (taking into account
         GPU-specific type conversions), and calls $fname on the resulting expression.
+
+        Can be applied to a pure function call, or a call prefixed with the `@cuda` macro.
+        In that case, kernel code generation conventions are used (wrt. argument conversions,
+        return values, etc).
         """ macro $(fname)(ex0)
             if ex0.head == :macrocall
                 # @cuda (...) f()
-                # TODO: pass kernel=true to irgen here
                 if Base.VERSION >= v"0.7.0-DEV.357"
                     ex0 = ex0.args[4]
                 else
                     ex0 = ex0.args[3]
                 end
+                kernel = true
+            else
+                kernel = false
             end
 
+            wrapper(func, types) = $kernel_arg ? $fname_wrapper(func, types, kernel) :
+                                                 $fname_wrapper(func, types)
+
             if Base.VERSION >= v"0.7.0-DEV.481"
-                Base.gen_call_with_extracted_types(__module__, $(Expr(:quote,fname_wrapper)), ex0)
+                Base.gen_call_with_extracted_types(__module__, wrapper, ex0)
             else
-                Base.gen_call_with_extracted_types($(Expr(:quote,fname_wrapper)), ex0)
+                Base.gen_call_with_extracted_types(wrapper, ex0)
             end
         end
     end

--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -116,10 +116,10 @@ for fname in [:code_lowered, :code_typed, :code_warntype, :code_llvm, :code_ptx,
 
     @eval begin
         function $fname_wrapper(func, types)
-            _, codegen_types, _ =
+            _, arg_types =
                 convert_arguments(fill(Symbol(), length(types.parameters)),
                                   types.parameters)
-            $fname(func, codegen_types)
+            $fname(func, arg_types)
         end
 
         @doc $"""

--- a/test/codegen.jl
+++ b/test/codegen.jl
@@ -91,7 +91,7 @@ end
     @eval ptx_entry(i) = (ptx_nonentry(i); nothing)
 
     asm = sprint(io->code_ptx(io, ptx_entry, (Int64,); kernel=true))
-    @test ismatch(r"\.visible \.entry julia_ptx_entry_", asm)
+    @test ismatch(r"\.visible \.entry ptxcall_ptx_entry_", asm)
     @test ismatch(r"\.visible \.func .+ julia_ptx_nonentry_", asm)
 end
 

--- a/test/codegen.jl
+++ b/test/codegen.jl
@@ -60,6 +60,22 @@ end
     @test !contains(ir, "inttoptr")
 end
 
+@testset "kernel calling convention" begin
+@testset "aggregate rewriting" begin
+    @eval codegen_aggregates(x) = nothing
+
+    @eval struct Aggregate
+        x::Int
+    end
+
+    ir = sprint(io->CUDAnative.code_llvm(io, codegen_aggregates, (Aggregate,)))
+    @test ismatch(r"@julia_codegen_aggregates_\d+\(%Aggregate.\d\* ", ir)
+
+    ir = sprint(io->CUDAnative.code_llvm(io, codegen_aggregates, (Aggregate,); kernel=true))
+    @test ismatch(r"@ptxcall_codegen_aggregates_\d+\(%Aggregate.\d\)", ir)
+end
+end
+
 end
 
 


### PR DESCRIPTION
Alternative to parametrizing the calling convention through eg. `CodegenParams`, idea from @vtjnash.

Depends on new version of LLVM.jl for maleadt/LLVM.jl#36