### PR TITLE
Align memory accesses according to the datatype.

### DIFF
--- a/src/device/array.jl
+++ b/src/device/array.jl
@@ -59,12 +59,14 @@ Base.length(g::CuDeviceArray) = prod(g.shape)
 
 @inline function Base.getindex(A::CuDeviceArray{T}, index::Int) where {T}
     @boundscheck checkbounds(A, index)
-    Base.pointerref(Base.unsafe_convert(Ptr{T}, A), index, 8)::T
+    align = alignment(T)
+    Base.pointerref(Base.unsafe_convert(Ptr{T}, A), index, align)::T
 end
 
 @inline function Base.setindex!(A::CuDeviceArray{T}, x, index::Int) where {T}
     @boundscheck checkbounds(A, index)
-    Base.pointerset(Base.unsafe_convert(Ptr{T}, A), convert(T, x)::T, index, 8)
+    align = alignment(T)
+    Base.pointerset(Base.unsafe_convert(Ptr{T}, A), convert(T, x)::T, index, align)
 end
 
 Base.IndexStyle(::Type{<:CuDeviceArray}) = Base.IndexLinear()

--- a/src/device/array.jl
+++ b/src/device/array.jl
@@ -59,13 +59,13 @@ Base.length(g::CuDeviceArray) = prod(g.shape)
 
 @inline function Base.getindex(A::CuDeviceArray{T}, index::Int) where {T}
     @boundscheck checkbounds(A, index)
-    align = alignment(T)
+    align = datatype_align(T)
     Base.pointerref(Base.unsafe_convert(Ptr{T}, A), index, align)::T
 end
 
 @inline function Base.setindex!(A::CuDeviceArray{T}, x, index::Int) where {T}
     @boundscheck checkbounds(A, index)
-    align = alignment(T)
+    align = datatype_align(T)
     Base.pointerset(Base.unsafe_convert(Ptr{T}, A), convert(T, x)::T, index, align)
 end
 

--- a/src/device/intrinsics/memory_shared.jl
+++ b/src/device/intrinsics/memory_shared.jl
@@ -2,8 +2,6 @@
 
 export @cuStaticSharedMem, @cuDynamicSharedMem
 
-alignment(::Type{T}) where {T} = ccall(:jl_alignment, Cint, (Csize_t,), sizeof(T))
-
 # FIXME: `shmem_id` increment in the macro isn't correct, as multiple parametrically typed
 #        functions will alias the id (but the size might be a parameter). but incrementing in
 #        the @generated function doesn't work, as it is supposed to be pure and identical

--- a/src/device/intrinsics/memory_shared.jl
+++ b/src/device/intrinsics/memory_shared.jl
@@ -51,7 +51,7 @@ function emit_static_shmem{N, T<:LLVMTypes}(id::Integer, jltyp::Type{T}, shape::
     llvmtyp = llvmtypes[jltyp]
 
     len = prod(shape)
-    align = alignment(jltyp)
+    align = datatype_align(jltyp)
 
     return quote
         Base.@_inline_meta
@@ -67,7 +67,7 @@ function emit_static_shmem{N}(id::Integer, jltyp::Type, shape::NTuple{N,<:Intege
     end
 
     len = prod(shape) * sizeof(jltyp)
-    align = alignment(jltyp)
+    align = datatype_align(jltyp)
 
     return quote
         Base.@_inline_meta
@@ -112,7 +112,7 @@ end
 function emit_dynamic_shmem{T<:LLVMTypes}(id::Integer, jltyp::Type{T}, shape::Union{Expr,Symbol}, offset)
     llvmtyp = llvmtypes[jltyp]
 
-    align = alignment(jltyp)
+    align = datatype_align(jltyp)
 
     return quote
         Base.@_inline_meta
@@ -127,7 +127,7 @@ function emit_dynamic_shmem(id::Integer, jltyp::Type, shape::Union{Expr,Symbol},
         error("cuDynamicSharedMem: non-isbits type '$jltyp' is not supported")
     end
 
-    align = alignment(jltyp)
+    align = datatype_align(jltyp)
 
     return quote
         Base.@_inline_meta

--- a/src/device/util.jl
+++ b/src/device/util.jl
@@ -132,3 +132,7 @@ function escape_llvm_string(io, s::AbstractString, esc::AbstractString)
     end
 end
 escape_llvm_string(s::AbstractString) = sprint(endof(s), escape_llvm_string, s, "\"")
+
+
+Base.@pure alignment(::Type{T}) where {T} =
+    convert(Int, ccall(:jl_alignment, Cint, (Csize_t,), sizeof(T)))


### PR DESCRIPTION
After #82, shared memory is aligned according to the datatype alignment rules. At the same time, the documentation for `cuMemAlloc` states `[the] allocated memory is suitably aligned for any kind of variable`. But some online sources state a 256-byte alignment from old documentation (`Any address of a variable residing in global memory or returned by one of the memory allocation routines from the driver or runtime API is always aligned to at least 256 bytes`), others seem to refer `textureAlignment`, while the PTX documentation for global loads states `[global] memory instructions support reading or writing words of size equal to 1, 2, 4, 8, or 16 bytes`...

So I'm not sure whether this is correct. Running our testsuite under `cuda-memcheck` now.