### PR TITLE
Add DevicePtr parameterized on address space

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
 julia 0.6
-CUDAdrv 0.4.2
-LLVM 0.3.6
+CUDAdrv 0.5.0
+LLVM 0.3.8

--- a/docs/src/lib/compilation.md
+++ b/docs/src/lib/compilation.md
@@ -2,5 +2,6 @@
 
 ```@docs
 CUDAnative.@cuda
+CUDAnative.cudaconvert
 CUDAnative.nearest_warpsize
 ```

--- a/src/device/array.jl
+++ b/src/device/array.jl
@@ -68,7 +68,7 @@ function Base.convert(::Type{CuDeviceArray{T,N,AS.Global}}, a::CuArray{T,N}) whe
     ptr = Base.unsafe_convert(Ptr{T}, owned_ptr)
     CuDeviceArray{T,N,AS.Global}(a.shape, DevicePtr{T,AS.Global}(ptr))
 end
-cudaconvert(::Type{CuArray{T,N}}) where {T,N} = CuDeviceArray{T,N,AS.Global}
+cudaconvert(a::CuArray{T,N}) where {T,N} = convert(CuDeviceArray{T,N,AS.Global}, a)
 
 
 ## indexing

--- a/src/device/array.jl
+++ b/src/device/array.jl
@@ -9,7 +9,8 @@ export
 """
     CuDeviceArray(dims, ptr)
     CuDeviceArray{T}(dims, ptr)
-    CuDeviceArray{T,N}(dims, ptr)
+    CuDeviceArray{T,A}(dims, ptr)
+    CuDeviceArray{T,A,N}(dims, ptr)
 
 Construct an `N`-dimensional dense CUDA device array with element type `T` wrapping a
 pointer, where `N` is determined from the length of `dims` and `T` is determined from the
@@ -23,61 +24,68 @@ CuDeviceArray
 # NOTE: we can't support the typical `tuple or series of integer` style construction,
 #       because we're currently requiring a trailing pointer argument.
 
-struct CuDeviceArray{T,N} <: AbstractArray{T,N}
+struct CuDeviceArray{T,N,A} <: AbstractArray{T,N}
     shape::NTuple{N,Int}
-    ptr::Ptr{T}
+    ptr::DevicePtr{T,A}
 
-    # inner constructors (exact types, ie. Int not <:Integer)
-    CuDeviceArray{T,N}(shape::NTuple{N,Int}, ptr::Ptr{T}) where {T,N} = new(shape, ptr)
+    # inner constructors, fully parameterized, exact types (ie. Int not <:Integer)
+    CuDeviceArray{T,N,A}(shape::NTuple{N,Int}, ptr::DevicePtr{T,A}) where {T,A,N} = new(shape,ptr)
 end
 
-const CuDeviceVector = CuDeviceArray{T,1} where {T}
-const CuDeviceMatrix = CuDeviceArray{T,2} where {T}
+const CuDeviceVector = CuDeviceArray{T,1,A} where {T,A}
+const CuDeviceMatrix = CuDeviceArray{T,2,A} where {T,A}
 
 # outer constructors, non-parameterized
-CuDeviceArray(dims::NTuple{N,<:Integer}, p::Ptr{T})                where {T,N} = CuDeviceArray{T,N}(dims, p)
-CuDeviceArray(len::Integer, p::Ptr{T})                             where {T}   = CuDeviceVector{T}((len,), p)
+CuDeviceArray(dims::NTuple{N,<:Integer}, p::DevicePtr{T,A})                where {T,A,N} = CuDeviceArray{T,N,A}(dims, p)
+CuDeviceArray(len::Integer,              p::DevicePtr{T,A})                where {T,A}   = CuDeviceVector{T,A}((len,), p)
 
 # outer constructors, partially parameterized
-(::Type{CuDeviceArray{T}})(dims::NTuple{N,<:Integer}, p::Ptr{T})   where {T,N} = CuDeviceArray{T,N}(dims, p)
-(::Type{CuDeviceArray{T}})(len::Integer, p::Ptr{T})                where {T}   = CuDeviceVector{T}((len,), p)
+(::Type{CuDeviceArray{T}})(dims::NTuple{N,<:Integer},   p::DevicePtr{T,A}) where {T,A,N} = CuDeviceArray{T,N,A}(dims, p)
+(::Type{CuDeviceArray{T}})(len::Integer,                p::DevicePtr{T,A}) where {T,A}   = CuDeviceVector{T,A}((len,), p)
+(::Type{CuDeviceArray{T,N}})(dims::NTuple{N,<:Integer}, p::DevicePtr{T,A}) where {T,A,N} = CuDeviceArray{T,N,A}(dims, p)
+(::Type{CuDeviceVector{T}})(len::Integer,               p::DevicePtr{T,A}) where {T,A}   = CuDeviceVector{T,A}((len,), p)
 
 # outer constructors, fully parameterized
-(::Type{CuDeviceArray{T,N}})(dims::NTuple{N,<:Integer}, p::Ptr{T}) where {T,N} = CuDeviceArray{T,N}(Int.(dims), p)
-(::Type{CuDeviceVector{T}})(len::Integer, p::Ptr{T})               where {T}   = CuDeviceVector{T}((Int(len),), p)
-
-Base.convert(::Type{CuDeviceArray{T,N}}, a::CuArray{T,N}) where {T,N} =
-    CuDeviceArray{T,N}(a.shape, Base.unsafe_convert(Ptr{T}, a.devptr))
-
-Base.unsafe_convert(::Type{Ptr{T}}, a::CuDeviceArray{T}) where {T} = a.ptr::Ptr{T}
+(::Type{CuDeviceArray{T,N,A}})(dims::NTuple{N,<:Integer}, p::DevicePtr{T,A}) where {T,A,N} = CuDeviceArray{T,N,A}(Int.(dims), p)
+(::Type{CuDeviceVector{T,A}})(len::Integer,               p::DevicePtr{T,A}) where {T,A}   = CuDeviceVector{T,A}((Int(len),), p)
 
 
-## array interface
+## getters
+
+Base.pointer(a::CuDeviceArray) = a.ptr
 
 Base.size(g::CuDeviceArray) = g.shape
 Base.length(g::CuDeviceArray) = prod(g.shape)
 
-@inline function Base.getindex(A::CuDeviceArray{T}, index::Int) where {T}
+
+## conversions
+
+Base.unsafe_convert(::Type{DevicePtr{T,A}}, a::CuDeviceArray{T,N,A}) where {T,A,N} = pointer(a)
+
+# from CuArray
+function Base.convert(::Type{CuDeviceArray{T,N,AS.Global}}, a::CuArray{T,N}) where {T,N}
+    owned_ptr = pointer(a)
+    ptr = Base.unsafe_convert(Ptr{T}, owned_ptr)
+    CuDeviceArray{T,N,AS.Global}(a.shape, DevicePtr{T,AS.Global}(ptr))
+end
+cudaconvert(::Type{CuArray{T,N}}) where {T,N} = CuDeviceArray{T,N,AS.Global}
+
+
+## indexing
+
+@inline function Base.getindex(A::CuDeviceArray{T}, index::Integer) where {T}
     @boundscheck checkbounds(A, index)
     align = datatype_align(T)
-    Base.pointerref(Base.unsafe_convert(Ptr{T}, A), index, align)::T
+    Base.unsafe_load(pointer(A), index, Val{align})::T
 end
 
-@inline function Base.setindex!(A::CuDeviceArray{T}, x, index::Int) where {T}
+@inline function Base.setindex!(A::CuDeviceArray{T}, x, index::Integer) where {T}
     @boundscheck checkbounds(A, index)
     align = datatype_align(T)
-    Base.pointerset(Base.unsafe_convert(Ptr{T}, A), convert(T, x)::T, index, align)
+    Base.unsafe_store!(pointer(A), x, index, Val{align})
 end
 
 Base.IndexStyle(::Type{<:CuDeviceArray}) = Base.IndexLinear()
-
-Base.show(io::IO, a::CuDeviceVector{T}) where {T} =
-    print(io, "$(length(a))-element device array at $(pointer(a))")
-Base.show(io::IO, a::CuDeviceArray{T,N}) where {T,N} =
-    print(io, "$(join(a.shape, '×')) device array at $(pointer(a))")
-
-
-## quirks
 
 # bounds checking is currently broken due to a PTX assembler issue (see #4)
 Base.checkbounds(::CuDeviceArray, I...) = nothing
@@ -88,10 +96,19 @@ struct CuBoundsError <: Exception end
 @inline Base.throw_boundserror(A::CuDeviceArray, I) =
     (Base.@_noinline_meta; throw(CuBoundsError()))
 
-# idem
+
+## other
+
+Base.show(io::IO, a::CuDeviceVector) =
+    print(io, "$(length(a))-element device array at $(pointer(a))")
+Base.show(io::IO, a::CuDeviceArray) =
+    print(io, "$(join(a.shape, '×')) device array at $(pointer(a))")
+
+Base.show(io::IO, mime::MIME"text/plain", a::CuDeviceArray) = show(io, a)
+
 function Base.unsafe_view(A::CuDeviceVector{T}, I::Vararg{Base.ViewIndex,1}) where {T}
     Base.@_inline_meta
-    ptr = Base.unsafe_convert(Ptr{T}, A) + (I[1].start-1)*sizeof(T)
+    ptr = pointer(A) + (I[1].start-1)*sizeof(T)
     len = I[1].stop - I[1].start + 1
     return CuDeviceArray(len, ptr)
 end

--- a/src/pointer.jl
+++ b/src/pointer.jl
@@ -1,0 +1,148 @@
+# Device pointer with address space information
+
+#
+# Address spaces
+#
+
+export
+    AS, addrspace
+
+abstract type AddressSpace end
+
+module AS
+
+using CUDAnative
+import CUDAnative: AddressSpace
+
+struct Generic  <: AddressSpace end
+struct Global   <: AddressSpace end
+struct Shared   <: AddressSpace end
+struct Constant <: AddressSpace end
+struct Local    <: AddressSpace end
+
+end
+
+
+#
+# Device pointer
+#
+
+struct DevicePtr{T,A}
+    ptr::Ptr{T}
+
+    # inner constructors, fully parameterized
+    DevicePtr{T,A}(ptr::Ptr{T}) where {T,A<:AddressSpace} = new(ptr)
+end
+
+# outer constructors, partially parameterized
+(::Type{DevicePtr{T}})(ptr::Ptr{T}) where {T} = DevicePtr{T,AS.Generic}(ptr)
+
+# outer constructors, non-parameterized
+DevicePtr(ptr::Ptr{T})              where {T} = DevicePtr{T,AS.Generic}(ptr)
+
+
+## getters
+
+Base.pointer(p::DevicePtr) = p.ptr
+
+Base.isnull(p::DevicePtr) = (pointer(p) == C_NULL)
+Base.eltype(::Type{<:DevicePtr{T}}) where {T} = T
+
+addrspace(x) = addrspace(typeof(x))
+addrspace(::Type{DevicePtr{T,A}}) where {T,A} = A
+
+
+## conversions
+
+# between regular and device pointers
+## simple conversions disallowed
+Base.convert(::Type{Ptr{T}}, p::DevicePtr{T})        where {T} = throw(InexactError())
+Base.convert(::Type{<:DevicePtr{T}}, p::Ptr{T})      where {T} = throw(InexactError())
+## unsafe ones are allowed
+Base.unsafe_convert(::Type{Ptr{T}}, p::DevicePtr{T}) where {T} = pointer(p)
+
+# defer conversions to DevicePtr to unsafe_convert
+Base.cconvert(::Type{<:DevicePtr}, x) = x
+
+# between device pointers
+Base.convert(::Type{<:DevicePtr}, p::DevicePtr)                         = throw(InexactError())
+Base.convert(::Type{DevicePtr{T,A}}, p::DevicePtr{T,A})   where {T,A}   = p
+Base.unsafe_convert(::Type{DevicePtr{T,A}}, p::DevicePtr) where {T,A}   = DevicePtr{T,A}(reinterpret(Ptr{T}, pointer(p)))
+## identical addrspaces
+Base.convert(::Type{DevicePtr{T,A}}, p::DevicePtr{U,A}) where {T,U,A} = Base.unsafe_convert(DevicePtr{T,A}, p)
+## convert to & from generic
+Base.convert(::Type{DevicePtr{T,AS.Generic}}, p::DevicePtr)               where {T}     = Base.unsafe_convert(DevicePtr{T,AS.Generic}, p)
+Base.convert(::Type{DevicePtr{T,A}}, p::DevicePtr{U,AS.Generic})          where {T,U,A} = Base.unsafe_convert(DevicePtr{T,A}, p)
+Base.convert(::Type{DevicePtr{T,AS.Generic}}, p::DevicePtr{T,AS.Generic}) where {T}     = p  # avoid ambiguities
+## unspecified, preserve source addrspace
+Base.convert(::Type{DevicePtr{T}}, p::DevicePtr{U,A}) where {T,U,A} = Base.unsafe_convert(DevicePtr{T,A}, p)
+
+
+## limited pointer arithmetic & comparison
+
+Base.:(==)(a::DevicePtr, b::DevicePtr) = pointer(a) == pointer(b) && addrspace(a) == addrspace(b)
+
+Base.isless(x::DevicePtr, y::DevicePtr) = Base.isless(pointer(x), pointer(y))
+Base.:(-)(x::DevicePtr, y::DevicePtr)   = pointer(x) - pointer(y)
+
+Base.:(+)(x::DevicePtr{T,A}, y::Integer) where {T,A} = DevicePtr{T,A}(pointer(x) + y)
+Base.:(-)(x::DevicePtr{T,A}, y::Integer) where {T,A} = DevicePtr{T,A}(pointer(x) - y)
+Base.:(+)(x::Integer, y::DevicePtr) = y + x
+
+
+## memory operations
+
+Base.convert(::Type{Int}, ::Type{AS.Generic})  = 0
+Base.convert(::Type{Int}, ::Type{AS.Global})   = 1
+Base.convert(::Type{Int}, ::Type{AS.Shared})   = 3
+Base.convert(::Type{Int}, ::Type{AS.Constant}) = 4
+Base.convert(::Type{Int}, ::Type{AS.Local})    = 5
+
+@generated function Base.unsafe_load(p::DevicePtr{T,A}, i::Integer=1,
+                                     ::Type{Val{align}}=Val{1}) where {T,A,align}
+    eltyp = convert(LLVMType, T)
+
+    # create a function
+    param_types = [LLVM.PointerType(eltyp),
+                   LLVM.IntType(sizeof(Int)*8, jlctx[])]
+    llvmf = create_llvmf(eltyp, param_types)
+
+    # generate IR
+    Builder(jlctx[]) do builder
+        entry = BasicBlock(llvmf, "entry", jlctx[])
+        position!(builder, entry)
+
+        ptr = gep!(builder, parameters(llvmf)[1], [parameters(llvmf)[2]])
+        ptr_with_as = addrspacecast!(builder, ptr, LLVM.PointerType(eltyp, convert(Int, A)))
+        val = load!(builder, ptr_with_as)
+        alignment!(val, align)
+        ret!(builder, val)
+    end
+
+    call_llvmf(llvmf, T, Tuple{Ptr{T}, Int}, :((pointer(p), Int(i-1))))
+end
+
+@generated function Base.unsafe_store!(p::DevicePtr{T,A}, x, i::Integer=1,
+                                       ::Type{Val{align}}=Val{1}) where {T,A,align}
+    eltyp = convert(LLVMType, T)
+
+    # create a function
+    param_types = [LLVM.PointerType(eltyp), eltyp,
+                   LLVM.IntType(sizeof(Int)*8, jlctx[])]
+    llvmf = create_llvmf(LLVM.VoidType(jlctx[]), param_types)
+
+    # generate IR
+    Builder(jlctx[]) do builder
+        entry = BasicBlock(llvmf, "entry", jlctx[])
+        position!(builder, entry)
+
+        ptr = gep!(builder, parameters(llvmf)[1], [parameters(llvmf)[3]])
+        ptr_with_as = addrspacecast!(builder, ptr, LLVM.PointerType(eltyp, convert(Int, A)))
+        val = parameters(llvmf)[2]
+        inst = store!(builder, val, ptr_with_as)
+        alignment!(inst, align)
+        ret!(builder)
+    end
+
+    call_llvmf(llvmf, Void, Tuple{Ptr{T}, T, Int}, :((pointer(p), convert(T,x), Int(i-1))))
+end

--- a/test/codegen.jl
+++ b/test/codegen.jl
@@ -81,6 +81,25 @@ end
 end
 end
 
+if Base.VERSION >= v"0.6.1-pre.1"
+    # JuliaLang/julia#22022 is required for AS-specific operations to work
+    # on certain structs, which this test verifies.
+    #
+    # Keep this test disabled until there's at least been one commit
+    # on the release-0.6 branch, which we assume to include #22022.
+
+    @testset "LLVM D32593" begin
+        @eval struct llvm_D32593_struct
+            foo::Float32
+            bar::Float32
+        end
+
+        @eval llvm_D32593(arr) = arr[1].foo
+
+        CUDAnative.code_llvm(DevNull, llvm_D32593, Tuple{CuDeviceVector{llvm_D32593_struct,AS.Global}})
+    end
+end
+
 end
 
 

--- a/test/execution.jl
+++ b/test/execution.jl
@@ -137,7 +137,8 @@ len = prod(dims)
     input_dev = CuArray(input)
     output_dev = similar(input_dev)
 
-    @cuda (1,len) exec_pass_ptr(input_dev.devptr, output_dev.devptr)
+    @cuda (1,len) exec_pass_ptr(Base.unsafe_convert(Ptr{Float32}, input_dev),
+                                Base.unsafe_convert(Ptr{Float32}, output_dev))
     output = Array(output_dev)
     @test input ≈ output
 end
@@ -161,7 +162,8 @@ end
     arr_dev = CuArray(arr)
     val_dev = CuArray(val)
 
-    @cuda (1,len) exec_pass_scalar(arr_dev.devptr, val_dev.devptr)
+    @cuda (1,len) exec_pass_scalar(Base.unsafe_convert(Ptr{Float32}, arr_dev),
+                                   Base.unsafe_convert(Ptr{Float32}, val_dev))
     @test arr[dims...] ≈ Array(val_dev)[1]
 end
 
@@ -187,7 +189,8 @@ end
     arr_dev = CuArray(arr)
     val_dev = CuArray(val)
 
-    @cuda (1,len) exec_pass_scalar_devfun(arr_dev.devptr, val_dev.devptr)
+    @cuda (1,len) exec_pass_scalar_devfun(Base.unsafe_convert(Ptr{Float32}, arr_dev),
+                                          Base.unsafe_convert(Ptr{Float32}, val_dev))
     @test arr[dims...] ≈ Array(val_dev)[1]
 end
 
@@ -207,7 +210,7 @@ end
     keeps = (true,)
     d_out = CuArray{Int}(1)
 
-    @cuda (1,1) exec_pass_tuples(keeps, d_out.devptr)
+    @cuda (1,1) exec_pass_tuples(keeps, Base.unsafe_convert(Ptr{Int}, d_out))
     @test Array(d_out) == [1]
 end
 
@@ -231,7 +234,10 @@ end
 
         return nothing
     end
-    @cuda (1,len) exec_pass_ghost(ExecGhost(), d_a.devptr, d_b.devptr, d_c.devptr)
+    @cuda (1,len) exec_pass_ghost(ExecGhost(),
+                                  Base.unsafe_convert(Ptr{Float32}, d_a),
+                                  Base.unsafe_convert(Ptr{Float32}, d_b),
+                                  Base.unsafe_convert(Ptr{Float32}, d_c))
 
     c = Array(d_c)
     @test a+b == c
@@ -245,7 +251,9 @@ end
 
         return nothing
     end
-    @cuda (1,len) exec_pass_ghost_aggregate(ExecGhost(), d_c.devptr, (42,))
+    @cuda (1,len) exec_pass_ghost_aggregate(ExecGhost(),
+                                            Base.unsafe_convert(Ptr{Float32}, d_c),
+                                            (42,))
 
     c = Array(d_c)
     @test all(val->val==42, c)
@@ -263,7 +271,7 @@ end
     A = CuArray(zeros(Float32, (1,)))
     x = Complex64(2,2)
 
-    @cuda (1, 1) exec_pass_immutables(A.devptr, x)
+    @cuda (1, 1) exec_pass_immutables(Base.unsafe_convert(Ptr{Float32}, A), x)
     @test Array(A) == Float32[imag(x)]
 end
 

--- a/test/pointer.jl
+++ b/test/pointer.jl
@@ -1,0 +1,59 @@
+@testset "pointer" begin
+
+# inner constructors
+
+const generic_null = CUDAnative.DevicePtr{Void,AS.Generic}(C_NULL)
+const global_null = CUDAnative.DevicePtr{Void,AS.Global}(C_NULL)
+const local_null = CUDAnative.DevicePtr{Void,AS.Local}(C_NULL)
+
+const C_NONNULL = Ptr{Void}(1)
+const generic_nonnull = CUDAnative.DevicePtr{Void,AS.Generic}(C_NONNULL)
+const global_nonnull = CUDAnative.DevicePtr{Void,AS.Global}(C_NONNULL)
+const local_nonnull = CUDAnative.DevicePtr{Void,AS.Local}(C_NONNULL)
+
+const C_ONE = Ptr{Int}(1)
+const generic_one = CUDAnative.DevicePtr{Int,AS.Generic}(C_ONE)
+const global_one = CUDAnative.DevicePtr{Int,AS.Global}(C_ONE)
+const local_one = CUDAnative.DevicePtr{Int,AS.Local}(C_ONE)
+
+# outer constructors
+@test CUDAnative.DevicePtr{Void}(C_NULL) == generic_null
+@test CUDAnative.DevicePtr(C_NULL) == generic_null
+
+# getters
+@test eltype(generic_null) == Void
+@test addrspace(generic_null) == AS.Generic
+@test isnull(generic_null)
+@test !isnull(generic_nonnull)
+
+# comparisons
+@test generic_null != generic_one
+@test generic_null != global_null
+@test local_null != global_null
+
+
+@testset "conversions" begin
+
+# between regular and device pointers
+
+@test_throws InexactError convert(Ptr{Void}, generic_null)
+@test_throws InexactError convert(CUDAnative.DevicePtr{Void}, C_NULL)
+
+@test Base.unsafe_convert(Ptr{Void}, generic_null) == C_NULL
+
+
+# between device pointers
+
+@test_throws InexactError convert(typeof(local_null), global_null) == local_null
+@test convert(typeof(generic_null), generic_null) == generic_null
+@test convert(typeof(global_null), global_null) == global_null
+@test Base.unsafe_convert(typeof(local_null), global_null) == local_null
+
+@test convert(typeof(global_null), global_one) == global_nonnull
+@test convert(typeof(generic_null), global_one) == generic_nonnull
+@test convert(typeof(global_null), generic_one) == global_nonnull
+@test convert(CUDAnative.DevicePtr{Void}, global_one) == global_nonnull
+
+end
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,7 @@ using Base.Test
 include("util.jl")
 
 include("base.jl")
+include("pointer.jl")
 
 if CUDAnative.configured
     # requiring a configured LLVM.jl


### PR DESCRIPTION
This PR refactors a core part of CUDAnative: how pointers are represented, and how they are accessed. It introduces a `DevicePtr` struct (`Ptr` + AS) with (WIP) intrinsics for accessing memory, specialized on the address space. The type is used in `CuDeviceArray`, making `getindex` faster for global loads (which LLVM couldn't figure out).

- [x] optimize `unsafe_store!`
- [x] tag required changes in LLVM.jl
- [x] tag CUDAdrv.jl
- [x] backport addrspace fixes to Julia 0.6

fixes #79
