### PR TITLE
Random LLVM-related improvements

### DIFF
--- a/src/CUDAnative.jl
+++ b/src/CUDAnative.jl
@@ -45,18 +45,22 @@ function __init__()
         error("Your set-up has changed. Please run Pkg.build(\"CUDAnative\") and restart Julia.")
     end
 
-    # instantiate a default device and context;
-    # this will be implicitly used through `CuCurrentContext`
-    # NOTE: although these conceptually match what the primary context is for,
-    #       we don't use that because it is refcounted separately
-    #       and might confuse / be confused by user operations
-    #       (eg. calling `unsafe_reset!` on a primary context)
-    default_device[] = CuDevice(0)
-    default_context[] = CuContext(default_device[])
-
     jlctx[] = LLVM.Context(cglobal(:jl_LLVMContext, Void))
 
     init_jit()
+
+    if haskey(ENV, "_") && basename(ENV["_"]) == "rr"
+        warn("Running under rr, which is incompatible with CUDA; disabling initialization.")
+    else
+        # instantiate a default device and context;
+        # this will be implicitly used through `CuCurrentContext`
+        # NOTE: although these conceptually match what the primary context is for,
+        #       we don't use that because it is refcounted separately
+        #       and might confuse / be confused by user operations
+        #       (eg. calling `unsafe_reset!` on a primary context)
+        default_device[] = CuDevice(0)
+        default_context[] = CuContext(default_device[])
+    end
 end
 
 end

--- a/src/cgutils.jl
+++ b/src/cgutils.jl
@@ -139,6 +139,7 @@ function create_llvmf(ret::LLVMType=LLVM.VoidType(jlctx[]), params::Vector{LLVMT
     llvmf_typ = LLVM.FunctionType(ret, params)
     llvmf = LLVM.Function(mod, name, llvmf_typ)
     push!(function_attributes(llvmf), EnumAttribute("alwaysinline"))
+    linkage!(llvmf, LLVM.API.LLVMPrivateLinkage)
 
     return llvmf
 end

--- a/src/execution.jl
+++ b/src/execution.jl
@@ -103,7 +103,7 @@ const compilecache = Dict{UInt, CuFunction}()
         if haskey(compilecache, key2)
             cuda_fun = compilecache[key2]
         else
-            cuda_fun, _ = cufunction(device(ctx), func, $arg_types)
+            cuda_fun, _ = cufunction(device(ctx), func, Tuple{$arg_types...})
             compilecache[key2] = cuda_fun
         end
 

--- a/src/jit.jl
+++ b/src/jit.jl
@@ -344,10 +344,9 @@ function check_invocation(func::ANY, tt::ANY; kernel::Bool=false)
 end
 
 # Main entry point for compiling a Julia function + argtypes to a callable CUDA function
-function cufunction(dev::CuDevice, func::ANY, types::ANY)
+function cufunction(dev::CuDevice, func::ANY, tt::ANY)
     CUDAnative.configured || error("CUDAnative.jl has not been configured; cannot JIT code.")
     @assert isa(func, Core.Function)
-    tt = Base.to_tuple_type(types)
 
     # select a capability level
     dev_cap = capability(dev)

--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -40,7 +40,7 @@ function code_llvm(io::IO, func::ANY, types::ANY=Tuple;
     check_invocation(func, tt; kernel=kernel)
     mod, entry = irgen(func, tt; kernel=kernel)
     if optimize
-        optimize!(mod, cap)
+        optimize!(mod, cap; exports=[entry])
     end
     if dump_module
         show(io, mod)

--- a/test/codegen.jl
+++ b/test/codegen.jl
@@ -124,8 +124,8 @@ end
     @eval @noinline ptx_child(i) = sink(i)
     @eval ptx_parent(i) = (ptx_child(i); nothing)
 
-    asm = sprint(io->code_ptx(io, ptx_parent, (Int64,)))
-    @test ismatch(r"call.uni \(retval0\),\s+julia_ptx_child_"m, asm)
+    asm = sprint(io->code_ptx(io, ptx_parent, Tuple{Int64}))
+    @test ismatch(r"call.uni\s+julia_ptx_child_"m, asm)
 end
 
 @testset "entry-point functions" begin
@@ -134,7 +134,8 @@ end
 
     asm = sprint(io->code_ptx(io, ptx_entry, (Int64,); kernel=true))
     @test ismatch(r"\.visible \.entry ptxcall_ptx_entry_", asm)
-    @test ismatch(r"\.visible \.func .+ julia_ptx_nonentry_", asm)
+    @test !ismatch(r"\.visible \.func julia_ptx_nonentry_", asm)
+    @test ismatch(r"\.func julia_ptx_nonentry_", asm)
 end
 
 @testset "delayed lookup" begin
@@ -166,16 +167,16 @@ end
         return
     end
 
-    asm = sprint(io->code_ptx(io, codegen_child_reuse_parent1, (Int,)))
-    @test ismatch(r".func .+ julia_codegen_child_reuse_child", asm)
+    asm = sprint(io->code_ptx(io, codegen_child_reuse_parent1, Tuple{Int}))
+    @test ismatch(r".func julia_codegen_child_reuse_child_", asm)
 
     @eval function codegen_child_reuse_parent2(i)
         codegen_child_reuse_child(i+1)
         return
     end
 
-    asm = sprint(io->code_ptx(io, codegen_child_reuse_parent2, (Int,)))
-    @test ismatch(r".func .+ julia_codegen_child_reuse_child", asm)
+    asm = sprint(io->code_ptx(io, codegen_child_reuse_parent2, Tuple{Int}))
+    @test ismatch(r".func julia_codegen_child_reuse_child_", asm)
 end
 
 @testset "child function reuse bis" begin

--- a/test/execution.jl
+++ b/test/execution.jl
@@ -7,7 +7,6 @@
 @testset "cufunction" begin
     @test_throws UndefVarError cufunction(exec_undefined_kernel, ())
 
-    cufunction(dev, exec_dummy, ())
     cufunction(dev, exec_dummy, Tuple{})
 
     # NOTE: other cases are going to be covered by tests below,


### PR DESCRIPTION
Could improve performance of compiler (parse less IR) and generated code (internalizing functions allows LLVM to ignore calling conventions).