### PR TITLE
Calculate i-1 using the type of the index.

### DIFF
--- a/src/pointer.jl
+++ b/src/pointer.jl
@@ -101,8 +101,8 @@ Base.convert(::Type{Int}, ::Type{AS.Local})    = 5
 if Base.VERSION >= v"0.6.1"
     # requires backport of JuliaLang/julia#22022
 
-    @generated function Base.unsafe_load(p::DevicePtr{T,A}, i::Integer=1,
-                                         ::Type{Val{align}}=Val{1}) where {T,A,align}
+    @generated function Base.unsafe_load(p::DevicePtr{T,A}, i::I=1,
+                                         ::Type{Val{align}}=Val{1}) where {T,A,align,I<:Integer}
         eltyp = convert(LLVMType, T)
 
         # create a function
@@ -122,11 +122,11 @@ if Base.VERSION >= v"0.6.1"
             ret!(builder, val)
         end
 
-        call_llvmf(llvmf, T, Tuple{Ptr{T}, Int}, :((pointer(p), Int(i-1))))
+        call_llvmf(llvmf, T, Tuple{Ptr{T}, Int}, :((pointer(p), Int(i-one(I)))))
     end
 
-    @generated function Base.unsafe_store!(p::DevicePtr{T,A}, x, i::Integer=1,
-                                           ::Type{Val{align}}=Val{1}) where {T,A,align}
+    @generated function Base.unsafe_store!(p::DevicePtr{T,A}, x, i::I=1,
+                                           ::Type{Val{align}}=Val{1}) where {T,A,align,I<:Integer}
         eltyp = convert(LLVMType, T)
 
         # create a function
@@ -147,7 +147,7 @@ if Base.VERSION >= v"0.6.1"
             ret!(builder)
         end
 
-        call_llvmf(llvmf, Void, Tuple{Ptr{T}, T, Int}, :((pointer(p), convert(T,x), Int(i-1))))
+        call_llvmf(llvmf, Void, Tuple{Ptr{T}, T, Int}, :((pointer(p), convert(T,x), Int(i-one(I)))))
     end
 else
     @inline Base.unsafe_load(p::DevicePtr{T,A}, i::Integer=1,


### PR DESCRIPTION
This makes it possible for LLVM to elide threadidx+1 -> unsafe_load(i-1).

eg. `vadd`, before:

```
.visible .entry ptxcall_add__61688(
        .param .align 8 .b8 ptxcall_add__61688_param_0[16],
        .param .align 8 .b8 ptxcall_add__61688_param_1[16],
        .param .align 8 .b8 ptxcall_add__61688_param_2[16]
)
{
        .reg .f32       %f<4>;
        .reg .s32       %r<4>;
        .reg .s64       %rd<14>;

        ld.param.u64    %rd1, [ptxcall_add__61688_param_0+8];
        ld.param.u64    %rd2, [ptxcall_add__61688_param_1+8];
        ld.param.u64    %rd3, [ptxcall_add__61688_param_2+8];
        mov.u32 %r2, %tid.x;
        .loc 1 5 0
        add.s32         %r3, %r2, 1;
        mul.wide.u32    %rd4, %r3, 4;
        add.s64         %rd5, %rd1, %rd4;
        add.s64         %rd6, %rd5, -4;
        cvta.to.global.u64      %rd7, %rd6;
        ld.global.f32   %f1, [%rd7];
        add.s64         %rd8, %rd2, %rd4;
        add.s64         %rd9, %rd8, -4;
        cvta.to.global.u64      %rd10, %rd9;
        ld.global.f32   %f2, [%rd10];
        .loc 1 6 0
        add.f32         %f3, %f1, %f2;
        add.s64         %rd11, %rd3, %rd4;
        add.s64         %rd12, %rd11, -4;
        cvta.to.global.u64      %rd13, %rd12;
        st.global.f32   [%rd13], %f3;
        ret;
}

```

after:

```
.visible .entry ptxcall_add__61688(
        .param .align 8 .b8 ptxcall_add__61688_param_0[16],
        .param .align 8 .b8 ptxcall_add__61688_param_1[16],
        .param .align 8 .b8 ptxcall_add__61688_param_2[16]
)
{
        .reg .f32       %f<4>;
        .reg .s32       %r<3>;
        .reg .s64       %rd<11>;

        ld.param.u64    %rd1, [ptxcall_add__61688_param_0+8];
        ld.param.u64    %rd2, [ptxcall_add__61688_param_1+8];
        ld.param.u64    %rd3, [ptxcall_add__61688_param_2+8];
        mov.u32 %r2, %tid.x;
        mul.wide.u32    %rd4, %r2, 4;
        add.s64         %rd5, %rd1, %rd4;
        cvta.to.global.u64      %rd6, %rd5;
        ld.global.f32   %f1, [%rd6];
        add.s64         %rd7, %rd2, %rd4;
        cvta.to.global.u64      %rd8, %rd7;
        ld.global.f32   %f2, [%rd8];
        .loc 1 6 0
        add.f32         %f3, %f1, %f2;
        add.s64         %rd9, %rd3, %rd4;
        cvta.to.global.u64      %rd10, %rd9;
        st.global.f32   [%rd10], %f3;
        ret;
}
```

which now is identical (in terms of instructions, not the order) to what nvcc generates