### PR TITLE
WIP: cooperative groups

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -121,6 +121,10 @@ function main()
     config[:cuobjdump] = find_binary("cuobjdump", toolkit_path)
     config[:ptxas] = find_binary("ptxas", toolkit_path)
 
+    if config[:cuda_version] >= v"9.0-" && VERSION < v"0.7.0-DEV.1"
+        warn("CUDA 9.0 is only supported on Julia 0.7; see https://github.com/JuliaGPU/CUDAnative.jl/pull/107")
+    end
+
 
     ## (re)generate ext.jl
 

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -122,7 +122,7 @@ function main()
     config[:ptxas] = find_binary("ptxas", toolkit_path)
 
     if config[:cuda_version] >= v"9.0-" && VERSION < v"0.7.0-DEV.1959"
-        warn("CUDA 9.0 is only supported on Julia 0.7; see https://github.com/JuliaGPU/CUDAnative.jl/pull/107")
+        error("CUDA 9.0 is only supported on Julia 0.7")
     end
 
 

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -121,7 +121,7 @@ function main()
     config[:cuobjdump] = find_binary("cuobjdump", toolkit_path)
     config[:ptxas] = find_binary("ptxas", toolkit_path)
 
-    if config[:cuda_version] >= v"9.0-" && VERSION < v"0.7.0-DEV.1"
+    if config[:cuda_version] >= v"9.0-" && VERSION < v"0.7.0-DEV.1959"
         warn("CUDA 9.0 is only supported on Julia 0.7; see https://github.com/JuliaGPU/CUDAnative.jl/pull/107")
     end
 

--- a/examples/pairwise.jl
+++ b/examples/pairwise.jl
@@ -107,5 +107,5 @@ const n = 10000
 const lat = rand(Float32, n) .* 45
 const lon = rand(Float32, n) .* -120
 
-using Base.Test
+VERSION >= v"0.7.0-DEV.1995" ? using Test : using Base.Test
 @test pairwise_dist_cpu(lat, lon) ≈ pairwise_dist_gpu(lat, lon)

--- a/examples/peakflops.jl
+++ b/examples/peakflops.jl
@@ -1,5 +1,5 @@
 using CUDAdrv, CUDAnative
-using Base.Test
+VERSION >= v"0.7.0-DEV.1995" ? using Test : using Base.Test
 
 "Dummy kernel doing 100 FMAs."
 function kernel_100fma(a, b, c, out)

--- a/examples/reduce/benchmark.jl
+++ b/examples/reduce/benchmark.jl
@@ -49,7 +49,7 @@ teardown_cuda(state) = ccall(Libdl.dlsym(lib, "teardown"), Void,
 
 # Correctness check (not part of verify.jl which is meant to run during testing)
 let
-    using Base.Test
+    VERSION >= v"0.7.0-DEV.1995" ? using Test : using Base.Test
     cuda_state = setup_cuda(input)
     cuda_val = run_cuda(cuda_state)
     teardown_cuda(cuda_state)

--- a/examples/reduce/verify.jl
+++ b/examples/reduce/verify.jl
@@ -1,4 +1,4 @@
-using Base.Test
+VERSION >= v"0.7.0-DEV.1995" ? using Test : using Base.Test
 include("reduce.jl")
 
 ctx = CuCurrentContext()

--- a/examples/scan.jl
+++ b/examples/scan.jl
@@ -69,7 +69,7 @@ cpu_accumulate!(+, cpu_a)
 gpu_a = CuArray(a)
 @cuda (cols,rows, cols*rows*sizeof(eltype(a))) gpu_accumulate!(+, gpu_a)
 
-using Base.Test
+VERSION >= v"0.7.0-DEV.1995" ? using Test : using Base.Test
 @test cpu_a ≈ Array(gpu_a)
 
 

--- a/examples/vadd.jl
+++ b/examples/vadd.jl
@@ -1,5 +1,5 @@
 using CUDAdrv, CUDAnative
-using Base.Test
+VERSION >= v"0.7.0-DEV.1995" ? using Test : using Base.Test
 
 function kernel_vadd(a, b, c)
     i = (blockIdx().x-1) * blockDim().x + threadIdx().x

--- a/src/CUDAnative.jl
+++ b/src/CUDAnative.jl
@@ -13,6 +13,7 @@ const configured = if isfile(ext)
 else
     # enable CUDAnative.jl to be loaded when the build failed, simplifying downstream use.
     # remove this when we have proper support for conditional modules.
+    const cuda_version = v"5.5"
     false
 end
 

--- a/src/device/intrinsics/synchronization.jl
+++ b/src/device/intrinsics/synchronization.jl
@@ -21,7 +21,7 @@ the warp.
 """
 sync_warp
 
-if cuda_version >= v"9.0-"
+if cuda_version >= v"9.0-" && VERSION >= v"0.7.0-DEV.1"
     @inline function sync_warp(mask::Integer=0xffffffff)
         return Base.llvmcall(
             """call void asm sideeffect "bar.warp.sync \$0;", "r"(i32 %0)

--- a/src/device/intrinsics/synchronization.jl
+++ b/src/device/intrinsics/synchronization.jl
@@ -21,7 +21,7 @@ the warp.
 """
 sync_warp
 
-if cuda_version >= v"9.0-" && VERSION >= v"0.7.0-DEV.1959"
+if cuda_version >= v"9.0-"
     @inline function sync_warp(mask::Integer=0xffffffff)
         return Base.llvmcall(
             """call void asm sideeffect "bar.warp.sync \$0;", "r"(i32 %0)

--- a/src/device/intrinsics/synchronization.jl
+++ b/src/device/intrinsics/synchronization.jl
@@ -1,6 +1,6 @@
 # Synchronization (B.6)
 
-export sync_threads
+export sync_threads, sync_warp
 
 """
     sync_threads()
@@ -10,3 +10,24 @@ shared memory accesses made by these threads prior to `sync_threads()` are visib
 threads in the block.
 """
 @inline sync_threads() = ccall("llvm.nvvm.barrier0", llvmcall, Void, ())
+
+"""
+    sync_warp(mask::Integer=0xffffffff)
+
+Waits threads in the warp, selected by means of the bitmask `mask`, have reached this point
+and all global and shared memory accesses made by these threads prior to `sync_warp()` are
+visible to those threads in the warp. The default value for `mask` selects all threads in
+the warp.
+"""
+sync_warp
+
+if cuda_version >= v"9.0-"
+    @inline function sync_warp(mask::Integer=0xffffffff)
+        return Base.llvmcall(
+            """call void asm sideeffect "bar.warp.sync \$0;", "r"(i32 %0)
+               ret void""",
+            Void, Tuple{UInt32}, convert(UInt32, mask))
+    end
+else
+    @inline sync_warp(mask::Integer=0xffffffff) = nothing
+end

--- a/src/device/intrinsics/synchronization.jl
+++ b/src/device/intrinsics/synchronization.jl
@@ -21,7 +21,7 @@ the warp.
 """
 sync_warp
 
-if cuda_version >= v"9.0-" && VERSION >= v"0.7.0-DEV.1"
+if cuda_version >= v"9.0-" && VERSION >= v"0.7.0-DEV.1959"
     @inline function sync_warp(mask::Integer=0xffffffff)
         return Base.llvmcall(
             """call void asm sideeffect "bar.warp.sync \$0;", "r"(i32 %0)

--- a/src/device/intrinsics/warp_shuffle.jl
+++ b/src/device/intrinsics/warp_shuffle.jl
@@ -20,12 +20,9 @@ for (name, mode, mask) in ((:shfl_up,   :up,   UInt32(0x00)),
 
     @eval begin
         export $name
-        @inline function $name(val::UInt32, srclane::Integer, width::Integer=$ws)
-            val = ccall($"$intrinsic", llvmcall, UInt32,
-                        (UInt32, UInt32, UInt32), val, convert(UInt32, srclane), $pack_expr)
-            sync_warp()
-            return val
-        end
+        @inline $name(val::UInt32, srclane::Integer, width::Integer=$ws) =
+            ccall($"$intrinsic", llvmcall, UInt32,
+                  (UInt32, UInt32, UInt32), val, convert(UInt32, srclane), $pack_expr)
     end
 end
 

--- a/src/device/intrinsics/warp_shuffle.jl
+++ b/src/device/intrinsics/warp_shuffle.jl
@@ -20,9 +20,12 @@ for (name, mode, mask) in ((:shfl_up,   :up,   UInt32(0x00)),
 
     @eval begin
         export $name
-        @inline $name(val::UInt32, srclane::Integer, width::Integer=$ws) =
-            ccall($"$intrinsic", llvmcall, UInt32,
-                  (UInt32, UInt32, UInt32), val, convert(UInt32, srclane), $pack_expr)
+        @inline function $name(val::UInt32, srclane::Integer, width::Integer=$ws)
+            val = ccall($"$intrinsic", llvmcall, UInt32,
+                        (UInt32, UInt32, UInt32), val, convert(UInt32, srclane), $pack_expr)
+            sync_warp()
+            return val
+        end
     end
 end
 

--- a/src/jit.jl
+++ b/src/jit.jl
@@ -321,7 +321,13 @@ function machine(cap::VersionNumber, triple::String)
 
     InitializeNVPTXTargetMC()
     cpu = "sm_$(cap.major)$(cap.minor)"
-    tm = TargetMachine(t, triple, cpu)
+    if cuda_version >= v"9.0-" && VERSION >= v"0.7.0-DEV.1"
+        # in the case of CUDA 9, we expose sync_warp which needs PTX ISA 6.0+
+        feat = "+ptx60"
+    else
+        feat = ""
+    end
+    tm = TargetMachine(t, triple, cpu, feat)
 
     return tm
 end

--- a/src/jit.jl
+++ b/src/jit.jl
@@ -321,7 +321,7 @@ function machine(cap::VersionNumber, triple::String)
 
     InitializeNVPTXTargetMC()
     cpu = "sm_$(cap.major)$(cap.minor)"
-    if cuda_version >= v"9.0-" && VERSION >= v"0.7.0-DEV.1"
+    if cuda_version >= v"9.0-" && VERSION >= v"0.7.0-DEV.1959"
         # in the case of CUDA 9, we expose sync_warp which needs PTX ISA 6.0+
         feat = "+ptx60"
     else

--- a/test/execution.jl
+++ b/test/execution.jl
@@ -78,9 +78,10 @@ end
         export exec_external_dummy
         exec_external_dummy() = return nothing
     end
+    import ...KernelModule
     @cuda (1,1) KernelModule.exec_external_dummy()
     @eval begin
-        using KernelModule
+        using ...KernelModule
         @cuda (1,1) exec_external_dummy()
     end
 

--- a/test/intrinsics.jl
+++ b/test/intrinsics.jl
@@ -331,6 +331,11 @@ end
 
 @testset "parallel synchronization and communication" begin
 
+@on_device sync_threads()
+
+@on_device sync_warp()
+@on_device sync_warp(0xffffffff)
+
 @testset "voting" begin
 
 @testset "ballot" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,8 @@
 using CUDAnative, CUDAdrv
 using Base.Test
 
+import LLVM
+
 @testset "CUDAnative" begin
 
 include("util.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using CUDAnative, CUDAdrv
-using Base.Test
+VERSION >= v"0.7.0-DEV.1995" ? using Test : using Base.Test
 
 import LLVM
 


### PR DESCRIPTION
Required on Volta, where threads can diverge within the warp. Blocked on NVPTX supporting PTX v6.0.
Probably also needs changes to the warp vote intrinsics.