### PR TITLE
Cope better with CUDA driver/toolkit mismatches.

### DIFF
--- a/src/CUDAnative.jl
+++ b/src/CUDAnative.jl
@@ -42,7 +42,7 @@ function __init__()
         return
     end
 
-    if CUDAdrv.version() != cuda_version ||
+    if CUDAdrv.version() != cuda_driver_version ||
         LLVM.version() != llvm_version ||
         VersionNumber(Base.libllvm_version) != julia_llvm_version
         error("Your set-up has changed. Please run Pkg.build(\"CUDAnative\") and restart Julia.")


### PR DESCRIPTION
Downgrade the selected version based on what nvcc and libcuda report.
This should prevent eg. passing too new PTX to ptxas. However, it might
still break eg. when compiling a too new libdevice with an older driver,
so we still warn at build-time.