### PR TITLE
Rework device code reflection.

### DIFF
--- a/docs/src/lib/reflection.md
+++ b/docs/src/lib/reflection.md
@@ -12,17 +12,18 @@ CUDAnative.code_sass
 
 ## Convenience macros
 
-For ease of use, CUDAnative.jl also implements `@code_` macros wrapping the above reflection
-functionality. These macros determines the type of arguments (taking into account GPU type
-conversions), and call the underlying `code_` function. In addition, these functions
-understand the `@cuda` invocation syntax, so you conveniently put them in front an existing
-`@cuda` invocation.
+For ease of use, CUDAnative.jl also implements `@device_code_` macros wrapping
+the above reflection functionality. These macros evaluate the expression
+argument, while tracing compilation and finally printing or returning the code
+for every invoked CUDA kernel. Do note that this evaluation can have side
+effects, as opposed to similarly-named `@code_` macros in Base which are free of
+side effects.
 
 ```@docs
-CUDAnative.@code_lowered
-CUDAnative.@code_typed
-CUDAnative.@code_warntype
-CUDAnative.@code_llvm
-CUDAnative.@code_ptx
-CUDAnative.@code_sass
+CUDAnative.@device_code_lowered
+CUDAnative.@device_code_typed
+CUDAnative.@device_code_warntype
+CUDAnative.@device_code_llvm
+CUDAnative.@device_code_ptx
+CUDAnative.@device_code_sass
 ```

--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -139,6 +139,14 @@ function emit_hooked_compilation(inner_hook, ex...)
     end
 end
 
+"""
+    @device_code_lowered ex
+
+Evaluates the expression `ex` and returns the result of [`Base.code_lowered`](@ref) for
+every compiled CUDA kernel.
+
+See also: [`Base.@code_lowered`](@ref)
+"""
 macro device_code_lowered(ex...)
     @gensym hook
     quote
@@ -151,6 +159,14 @@ macro device_code_lowered(ex...)
     end
 end
 
+"""
+    @device_code_typed ex
+
+Evaluates the expression `ex` and returns the result of [`Base.code_typed`](@ref) for
+every compiled CUDA kernel.
+
+See also: [`Base.@code_typed`](@ref)
+"""
 macro device_code_typed(ex...)
     @gensym hook
     quote
@@ -163,6 +179,14 @@ macro device_code_typed(ex...)
     end
 end
 
+"""
+    @device_code_warntype [io::IO=STDOUT] ex
+
+Evaluates the expression `ex` and prints the result of [`Base.code_warntype`](@ref) to `io`
+for every compiled CUDA kernel.
+
+See also: [`Base.@code_warntype`](@ref)
+"""
 macro device_code_warntype(ex...)
     function hook(func, tt, _; io::IO=STDOUT)
         code_warntype(io, func, tt)
@@ -170,6 +194,16 @@ macro device_code_warntype(ex...)
     emit_hooked_compilation(hook, ex...)
 end
 
+"""
+    @device_code_llvm [io::IO=STDOUT] [optimize::Bool=true] [dump_module::Bool=false] ex
+
+Evaluates the expression `ex` and prints the result of [`Base.code_llvm`](@ref) to `io` for
+every compiled CUDA kernel. The `optimize` keyword argument determines whether the code is
+optimized, and `dump_module` can be used to print the entire LLVM module instead of only the
+entry-point function.
+
+See also: [`Base.@code_llvm`](@ref)
+"""
 macro device_code_llvm(ex...)
     function hook(func, tt, cap; io::IO=STDOUT, optimize::Bool=true, dump_module::Bool=false)
         code_llvm(io, func, tt; cap=cap, optimize=optimize, dump_module=dump_module)
@@ -177,6 +211,12 @@ macro device_code_llvm(ex...)
     emit_hooked_compilation(hook, ex...)
 end
 
+"""
+    @device_code_ptx [io::IO=STDOUT] ex
+
+Evaluates the expression `ex` and prints the result of [`CUDAnative.code_ptx`](@ref) to `io`
+for every compiled CUDA kernel.
+"""
 macro device_code_ptx(ex...)
     function hook(func, tt, cap; io::IO=STDOUT)
         code_ptx(io, func, tt; cap=cap)
@@ -184,6 +224,12 @@ macro device_code_ptx(ex...)
     emit_hooked_compilation(hook, ex...)
 end
 
+"""
+    @device_code_sass [io::IO=STDOUT] ex
+
+Evaluates the expression `ex` and prints the result of [`CUDAnative.code_sass`](@ref) to
+`io` for every compiled CUDA kernel.
+"""
 macro device_code_sass(ex...)
     function hook(func, tt, cap; io::IO=STDOUT)
         code_sass(io, func, tt; cap=cap)

--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -1,13 +1,5 @@
 # code reflection entry-points
 
-export
-    @code_lowered, @code_typed, @code_warntype,
-    code_llvm, code_ptx, code_sass, @code_llvm, @code_ptx, @code_sass
-
-#
-# code_* replacements
-#
-
 # Return the capability of the current context's device, or a sane fall-back.
 function current_capability()
     fallback = minimum(target_support)
@@ -23,15 +15,22 @@ function current_capability()
     return capability(device(ctx))
 end
 
+
+#
+# code_* replacements
+#
+
 """
     code_llvm([io], f, types; optimize=true, dump_module=false, cap::VersionNumber)
 
-Prints the LLVM IR generated for the method matching the given generic function and type
-signature to `io` which defaults to `STDOUT`. The IR is optimized according to `optimize`
-(defaults to true), and the entire module, including headers and other functions, is dumped
-if `dump_module` is set (defaults to false). The device capability `cap` to generate code
-for defaults to the current active device's capability, or v"2.0" if there is no such active
-context.
+Prints the device LLVM IR generated for the method matching the given generic function and
+type signature to `io` which defaults to `STDOUT`. The IR is optimized according to
+`optimize` (defaults to true), and the entire module, including headers and other functions,
+is dumped if `dump_module` is set (defaults to false). The device capability `cap` to
+generate code for defaults to the current active device's capability, or v"2.0" if there is
+no such active context.
+
+See also: [`@device_code_llvm`](@ref), [`Base.code_llvm`](@ref)
 """
 function code_llvm(io::IO, @nospecialize(func::Core.Function), @nospecialize(types=Tuple);
                    optimize::Bool=true, dump_module::Bool=false,
@@ -62,6 +61,8 @@ type signature to `io` which defaults to `STDOUT`. The device capability `cap` t
 code for defaults to the current active device's capability, or v"2.0" if there is no such
 active context. The optional `kernel` parameter indicates whether the function in question
 is an entry-point function, or a regular device function.
+
+See also: [`@device_code_ptx`](@ref)
 """
 function code_ptx(io::IO, @nospecialize(func::Core.Function), @nospecialize(types=Tuple);
                   cap::VersionNumber=current_capability(), kernel::Bool=false)
@@ -82,10 +83,10 @@ code_ptx(@nospecialize(func), @nospecialize(types=Tuple); kwargs...) =
 Prints the SASS code generated for the method matching the given generic function and type
 signature to `io` which defaults to `STDOUT`. The device capability `cap` to generate code
 for defaults to the current active device's capability, or v"2.0" if there is no such active
-context.
-
-Note that the method needs to be a valid entry-point kernel, ie. it should not return any
+context. The method needs to be a valid entry-point kernel, eg. it should not return any
 values.
+
+See also: [`@device_code_sass`](@ref)
 """
 function code_sass(io::IO, @nospecialize(func::Core.Function), @nospecialize(types=Tuple);
                    cap::VersionNumber=current_capability())
@@ -111,42 +112,55 @@ code_sass(@nospecialize(func), @nospecialize(types=Tuple); kwargs...) =
 
 
 #
-# @code_* replacements
+# @device_code_* functions
 #
 
-function gen_call_with_extracted_types(f, ex)
-    :($f($(esc(ex.args[1])), Base.typesof(cudaconvert.(($(esc.(ex.args[2:end])...),))...)))
-end
+export @device_code_lowered, @device_code_typed, @device_code_warntype,
+       @device_code_llvm, @device_code_ptx, @device_code_sass
 
-for (fname,kernel_arg) in [(:code_lowered, false), (:code_typed, false), (:code_warntype, false),
-                           (:code_llvm, true), (:code_ptx, true), (:code_sass, false)]
-    # TODO: test the kernel_arg-based behavior
-    @eval begin
-        @doc $"""
-            $fname
-        Extracts the relevant function call from any `@cuda` invocation, evaluates the
-        arguments to the function or macro call, determines their types (taking into account
-        GPU-specific type conversions), and calls $fname on the resulting expression.
-        Can be applied to a pure function call, or a call prefixed with the `@cuda` macro.
-        In that case, kernel code generation conventions are used (wrt. argument conversions,
-        return values, etc).
-        """ macro $(fname)(ex0)
-            if ex0.head == :macrocall
-                # @cuda (...) f()
-                if Base.VERSION >= v"0.7.0-DEV.357"
-                    ex0 = ex0.args[4]
-                else
-                    ex0 = ex0.args[3]
-                end
-                kernel = true
-            else
-                kernel = false
-            end
+function emit_hooked_compilation(inner_hook, ex)
+    quote
+        # wipe the compile cache to force recompilation
+        empty!(CUDAnative.compilecache)
 
-            wrapper(func, types) = $kernel_arg ? $fname(func, types, kernel = kernel) :
-                                                 $fname(func, types)
-
-            gen_call_with_extracted_types(wrapper, ex0)
+        @assert CUDAnative.compile_hook[] == nothing
+        try
+            CUDAnative.compile_hook[] = $inner_hook
+            $(esc(ex))
+        finally
+            CUDAnative.compile_hook[] = nothing
         end
     end
+end
+
+macro device_code_lowered(ex)
+    # NOTE: these normally return values, so print instead
+    hook = (func, tt, _) -> println(code_lowered(func, tt))
+    emit_hooked_compilation(hook, ex)
+end
+
+macro device_code_typed(ex)
+    # NOTE: these normally return values, so print instead
+    hook = (func, tt, _) -> println(code_typed(func, tt))
+    emit_hooked_compilation(hook, ex)
+end
+
+macro device_code_warntype(ex)
+    hook = (func, tt, _) -> code_warntype(func, tt)
+    emit_hooked_compilation(hook, ex)
+end
+
+macro device_code_llvm(ex)
+    hook = (func, tt, cap) -> code_llvm(func, tt; cap=cap)
+    emit_hooked_compilation(hook, ex)
+end
+
+macro device_code_ptx(ex)
+    hook = (func, tt, cap) -> code_ptx(func, tt; cap=cap)
+    emit_hooked_compilation(hook, ex)
+end
+
+macro device_code_sass(ex)
+    hook = (func, tt, cap) -> code_sass(func, tt; cap=cap)
+    emit_hooked_compilation(hook, ex)
 end

--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -134,6 +134,8 @@ function emit_hooked_compilation(inner_hook, ex...)
         finally
             CUDAnative.compile_hook[] = nothing
         end
+
+        nothing
     end
 end
 

--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -161,7 +161,7 @@ macro device_code_lowered(ex...)
     @gensym hook
     quote
         buf = Any[]
-        function $hook(func, tt, _)
+        function $hook(func, tt, cap)
             append!(buf, code_lowered(func, tt))
         end
         $(emit_hooked_compilation(hook, ex...))
@@ -181,7 +181,7 @@ macro device_code_typed(ex...)
     @gensym hook
     quote
         buf = Any[]
-        function $hook(func, tt, _)
+        function $hook(func, tt, cap)
             append!(buf, code_typed(func, tt))
         end
         $(emit_hooked_compilation(hook, ex...))
@@ -198,7 +198,7 @@ for every compiled CUDA kernel.
 See also: [`Base.@code_warntype`](@ref)
 """
 macro device_code_warntype(ex...)
-    function hook(func, tt, _; io::IO=STDOUT)
+    function hook(func, tt, cap; io::IO=STDOUT)
         code_warntype(io, func, tt)
     end
     emit_hooked_compilation(hook, ex...)

--- a/test/codegen_device.jl
+++ b/test/codegen_device.jl
@@ -8,8 +8,8 @@
     @eval sass_valid_kernel() = nothing
     @eval sass_invalid_kernel() = 1
 
-    @test code_sass(DevNull, sass_valid_kernel, Tuple{}) == nothing
-    @test_throws ArgumentError code_sass(DevNull, sass_invalid_kernel, Tuple{}) == nothing
+    @test CUDAnative.code_sass(DevNull, sass_valid_kernel, Tuple{}) == nothing
+    @test_throws ArgumentError CUDAnative.code_sass(DevNull, sass_invalid_kernel, Tuple{})
 end
 
 end

--- a/test/execution.jl
+++ b/test/execution.jl
@@ -38,6 +38,8 @@ end
     @device_code_llvm io=DevNull @cuda (1,1) exec_dummy()
     @device_code_ptx io=DevNull @cuda (1,1) exec_dummy()
     @device_code_sass io=DevNull @cuda (1,1) exec_dummy()
+
+    @test_throws ErrorException @device_code_lowered nothing
 end
 
 

--- a/test/execution.jl
+++ b/test/execution.jl
@@ -25,19 +25,19 @@ end
 @testset "reflection" begin
     @cuda (1,1) exec_dummy()
 
-    @device_code_lowered @cuda (1,1) exec_dummy()
-    @device_code_typed @cuda (1,1) exec_dummy()
-    @grab_output @device_code_warntype @cuda (1,1) exec_dummy()
-    @grab_output @device_code_llvm @cuda (1,1) exec_dummy()
-    @grab_output @device_code_ptx @cuda (1,1) exec_dummy()
-    @grab_output @device_code_sass @cuda (1,1) exec_dummy()
-
     CUDAnative.code_lowered(exec_dummy, Tuple{})
     CUDAnative.code_typed(exec_dummy, Tuple{})
     CUDAnative.code_warntype(DevNull, exec_dummy, Tuple{})
     CUDAnative.code_llvm(DevNull, exec_dummy, Tuple{})
     CUDAnative.code_ptx(DevNull, exec_dummy, Tuple{})
     CUDAnative.code_sass(DevNull, exec_dummy, Tuple{})
+
+    @device_code_lowered @cuda (1,1) exec_dummy()
+    @device_code_typed @cuda (1,1) exec_dummy()
+    @device_code_warntype io=DevNull @cuda (1,1) exec_dummy()
+    @device_code_llvm io=DevNull @cuda (1,1) exec_dummy()
+    @device_code_ptx io=DevNull @cuda (1,1) exec_dummy()
+    @device_code_sass io=DevNull @cuda (1,1) exec_dummy()
 end
 
 

--- a/test/execution.jl
+++ b/test/execution.jl
@@ -25,34 +25,19 @@ end
 @testset "reflection" begin
     @cuda (1,1) exec_dummy()
 
-    @grab_output CUDAnative.@code_lowered @cuda (1,1) exec_dummy()
-    @grab_output CUDAnative.@code_typed @cuda (1,1) exec_dummy()
-    @grab_output CUDAnative.@code_warntype @cuda (1,1) exec_dummy()
-    @grab_output CUDAnative.@code_llvm @cuda (1,1) exec_dummy()
-    @grab_output CUDAnative.@code_ptx @cuda (1,1) exec_dummy()
-    @grab_output CUDAnative.@code_sass @cuda (1,1) exec_dummy()
+    @device_code_lowered @cuda (1,1) exec_dummy()
+    @device_code_typed @cuda (1,1) exec_dummy()
+    @grab_output @device_code_warntype @cuda (1,1) exec_dummy()
+    @grab_output @device_code_llvm @cuda (1,1) exec_dummy()
+    @grab_output @device_code_ptx @cuda (1,1) exec_dummy()
+    @grab_output @device_code_sass @cuda (1,1) exec_dummy()
 
-    @grab_output CUDAnative.@code_lowered exec_dummy()
-    @grab_output CUDAnative.@code_typed exec_dummy()
-    @grab_output CUDAnative.@code_warntype exec_dummy()
-    @grab_output CUDAnative.@code_llvm exec_dummy()
-    @grab_output CUDAnative.@code_ptx exec_dummy()
-    @grab_output CUDAnative.@code_sass exec_dummy()
-end
-
-
-@testset "reflection with argument conversion" begin
-    @eval exec_dummy_array(a, i) = (a[1] = i; return nothing)
-
-    a = CuTestArray([1])
-
-    @grab_output CUDAnative.@code_llvm @cuda (1,1) exec_dummy_array(a, 1)
-    @grab_output CUDAnative.@code_ptx @cuda (1,1) exec_dummy_array(a, 1)
-    @grab_output CUDAnative.@code_sass @cuda (1,1) exec_dummy_array(a, 1)
-
-    @grab_output CUDAnative.@code_llvm exec_dummy_array(a, 1)
-    @grab_output CUDAnative.@code_ptx exec_dummy_array(a, 1)
-    @grab_output CUDAnative.@code_sass exec_dummy_array(a, 1)
+    CUDAnative.code_lowered(exec_dummy, Tuple{})
+    CUDAnative.code_typed(exec_dummy, Tuple{})
+    CUDAnative.code_warntype(DevNull, exec_dummy, Tuple{})
+    CUDAnative.code_llvm(DevNull, exec_dummy, Tuple{})
+    CUDAnative.code_ptx(DevNull, exec_dummy, Tuple{})
+    CUDAnative.code_sass(DevNull, exec_dummy, Tuple{})
 end
 
 


### PR DESCRIPTION
This PR changes device code reflection to make it consistent and improve user friendliness.

Before, we extended `Base.code_*` and corresponding macro's, which was:
- inconsistent, because depending on how it was (mis)used, it could return CPU or GPU code (eg. `CUDAnative.@code_llvm` stuck in front of a proper GPU function call vs. broadcasting over a `CuArray`)
- limited, as it the macros really only could be used in front of `@cuda` calls
- annoying, because you need to specify whether you want to use Base or CUDAnative reflection

What I've tried in this PR:
- still have `code_` functions for generating code from known device method calls, but without extending Base
- remove the `@code_` macros, and replace them with `@device_code` macros that are guaranteed to always return device code

To implement those `@device_code` macros, I've added a tiny hook mechanism to CUDAnative that makes it possible to intercept compile jobs. That makes it possible to, eg., stick it in front of CPU code that calls into CUDAnative somewhere down the line, such as CuArrays.

Disadvantage of that approach: calling `@device_code` macros actually need to evaluate the RHS, so it'll have side-effects.

TODO:
- [x] extra arguments: optimize, dump_module, etc. macro kwargs are ugly
- [x] fix tests
- [x] documentation

Comments? Suggestions?

cc @denizyuret @vchuravy @MikeInnes 
ref https://github.com/denizyuret/Knet.jl/issues/198#issuecomment-349275139