### PR TITLE
Support for loading values through the texture cache (__ldg)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -12,12 +12,11 @@
 * Use LLVM's linker with `InternalizeLinkedSymbols` when linking libdevice
   (simplifies code in jit.jl)
 
-* Pass 'Val{T}()' instead of 'Val{T}', easier on the compiler
-
 
 ## CUDA support/interfacing
 
 * ReadOnlyArray --> `getindex` does `__ldg`
+
 
 
 # Ideas

--- a/docs/src/lib/device/array.md
+++ b/docs/src/lib/device/array.md
@@ -6,4 +6,5 @@ plain, dense fashion. This is the device-counterpart to CUDAdrv's `CuArray`, and
 
 ```@docs
 CUDAnative.CuDeviceArray
+CUDAnative.ldg
 ```

--- a/src/cgutils.jl
+++ b/src/cgutils.jl
@@ -200,7 +200,7 @@ end
     words = Symbol[]
     for i in 1:Core.sizeof(val)÷4
         word = Symbol("word$i")
-        push!(ex.args, :( $word = extract_word(val, Val{$i}()) ))
+        push!(ex.args, :( $word = extract_word(val, Val($i)) ))
         push!(words, word)
     end
 
@@ -212,7 +212,7 @@ end
     # reassemble
     push!(ex.args, :( out = zero(val) ))
     for (i,word) in enumerate(words)
-        push!(ex.args, :( out = insert_word(out, $word, Val{$i}()) ))
+        push!(ex.args, :( out = insert_word(out, $word, Val($i)) ))
     end
 
     push!(ex.args, :( out ))

--- a/src/device/array.jl
+++ b/src/device/array.jl
@@ -11,33 +11,35 @@ export
     CuDeviceArray{T}(dims, ptr)
     CuDeviceArray{T,A}(dims, ptr)
     CuDeviceArray{T,A,N}(dims, ptr)
+    CuDeviceArray{T,A,N,C}(dims, ptr)
 
 Construct an `N`-dimensional dense CUDA device array with element type `T` wrapping a
 pointer, where `N` is determined from the length of `dims` and `T` is determined from the
 type of `ptr`. `dims` may be a single scalar, or a tuple of integers corresponding to the
 lengths in each dimension). If the rank `N` is supplied explicitly as in `Array{T,N}(dims)`,
 then it must match the length of `dims`. The same applies to the element type `T`, which
-should match the type of the pointer `ptr`.
+should match the type of the pointer `ptr`. The `C` param indicates whether accesses should
+be cached, defaulting to false.
 """
 CuDeviceArray
 
 # NOTE: we can't support the typical `tuple or series of integer` style construction,
 #       because we're currently requiring a trailing pointer argument.
 
-struct CuDeviceArray{T,N,A} <: AbstractArray{T,N}
+struct CuDeviceArray{T,N,A,C} <: AbstractArray{T,N}
     shape::NTuple{N,Int}
     ptr::DevicePtr{T,A}
 
     # inner constructors, fully parameterized, exact types (ie. Int not <:Integer)
-    CuDeviceArray{T,N,A}(shape::NTuple{N,Int}, ptr::DevicePtr{T,A}) where {T,A,N} = new(shape,ptr)
+    CuDeviceArray{T,N,A,C}(shape::NTuple{N,Int}, ptr::DevicePtr{T,A}) where {T,A,N,C} = new(shape,ptr)
 end
 
-const CuDeviceVector = CuDeviceArray{T,1,A} where {T,A}
-const CuDeviceMatrix = CuDeviceArray{T,2,A} where {T,A}
+const CuDeviceVector = CuDeviceArray{T,1,A,C} where {T,A,C}
+const CuDeviceMatrix = CuDeviceArray{T,2,A,C} where {T,A,C}
 
 # outer constructors, non-parameterized
-CuDeviceArray(dims::NTuple{N,<:Integer}, p::DevicePtr{T,A})                where {T,A,N} = CuDeviceArray{T,N,A}(dims, p)
-CuDeviceArray(len::Integer,              p::DevicePtr{T,A})                where {T,A}   = CuDeviceVector{T,A}((len,), p)
+CuDeviceArray(dims::NTuple{N,<:Integer}, p::DevicePtr{T,A}) where {T,A,N} = CuDeviceArray{T,N,A}(dims, p)
+CuDeviceArray(len::Integer,              p::DevicePtr{T,A}) where {T,A}   = CuDeviceVector{T,A}((len,), p)
 
 # outer constructors, partially parameterized
 CuDeviceArray{T}(dims::NTuple{N,<:Integer},   p::DevicePtr{T,A}) where {T,A,N} = CuDeviceArray{T,N,A}(dims, p)
@@ -46,8 +48,8 @@ CuDeviceArray{T,N}(dims::NTuple{N,<:Integer}, p::DevicePtr{T,A}) where {T,A,N} =
 CuDeviceVector{T}(len::Integer,               p::DevicePtr{T,A}) where {T,A}   = CuDeviceVector{T,A}((len,), p)
 
 # outer constructors, fully parameterized
-CuDeviceArray{T,N,A}(dims::NTuple{N,<:Integer}, p::DevicePtr{T,A}) where {T,A,N} = CuDeviceArray{T,N,A}(Int.(dims), p)
-CuDeviceVector{T,A}(len::Integer,               p::DevicePtr{T,A}) where {T,A}   = CuDeviceVector{T,A}((Int(len),), p)
+CuDeviceArray{T,N,A}(dims::NTuple{N,<:Integer}, p::DevicePtr{T,A}) where {T,A,N} = CuDeviceArray{T,N,A,false}(Int.(dims), p)
+CuDeviceVector{T,A}(len::Integer,               p::DevicePtr{T,A}) where {T,A}   = CuDeviceVector{T,A,false}((Int(len),), p)
 
 
 ## getters

--- a/src/device/array.jl
+++ b/src/device/array.jl
@@ -75,13 +75,13 @@ cudaconvert(a::CuArray{T,N}) where {T,N} = convert(CuDeviceArray{T,N,AS.Global},
 @inline function Base.getindex(A::CuDeviceArray{T}, index::Integer) where {T}
     @boundscheck checkbounds(A, index)
     align = datatype_align(T)
-    Base.unsafe_load(pointer(A), index, Val{align})::T
+    Base.unsafe_load(pointer(A), index, Val(align))::T
 end
 
 @inline function Base.setindex!(A::CuDeviceArray{T}, x, index::Integer) where {T}
     @boundscheck checkbounds(A, index)
     align = datatype_align(T)
-    Base.unsafe_store!(pointer(A), x, index, Val{align})
+    Base.unsafe_store!(pointer(A), x, index, Val(align))
 end
 
 Base.IndexStyle(::Type{<:CuDeviceArray}) = Base.IndexLinear()

--- a/src/device/intrinsics/memory_shared.jl
+++ b/src/device/intrinsics/memory_shared.jl
@@ -53,7 +53,7 @@ macro cuStaticSharedMem(typ, dims)
     global shmem_id
     id = shmem_id::Int += 1
 
-    return :(generate_static_shmem(Val{$id}, $(esc(typ)), Val{$(esc(dims))}))
+    return :(generate_static_shmem(Val($id), $(esc(typ)), Val($(esc(dims)))))
 end
 
 # types with known corresponding LLVM type
@@ -88,8 +88,7 @@ function emit_static_shmem(id::Integer, jltyp::Type, shape::NTuple{N,<:Integer})
     end
 end
 
-@generated function generate_static_shmem(::Type{Val{ID}}, ::Type{T},
-                                          ::Type{Val{D}}) where {ID,T,D}
+@generated function generate_static_shmem(::Val{ID}, ::Type{T}, ::Val{D}) where {ID,T,D}
     return emit_static_shmem(ID, T, tuple(D...))
 end
 
@@ -116,7 +115,7 @@ macro cuDynamicSharedMem(typ, dims, offset=0)
     global shmem_id
     id = shmem_id::Int += 1
 
-    return :(generate_dynamic_shmem(Val{$id}, $(esc(typ)), $(esc(dims)), $(esc(offset))))
+    return :(generate_dynamic_shmem(Val($id), $(esc(typ)), $(esc(dims)), $(esc(offset))))
 end
 
 # TODO: boundscheck against %dynamic_smem_size (currently unsupported by LLVM)
@@ -151,8 +150,7 @@ function emit_dynamic_shmem(id::Integer, jltyp::Type, shape::Union{Expr,Symbol},
     end
 end
 
-@generated function generate_dynamic_shmem(::Type{Val{ID}}, ::Type{T}, dims,
-                                           offset) where {ID,T}
+@generated function generate_dynamic_shmem(::Val{ID}, ::Type{T}, dims, offset) where {ID,T}
     return emit_dynamic_shmem(ID, T, :(dims), :(offset))
 end
 

--- a/src/device/intrinsics/output.jl
+++ b/src/device/intrinsics/output.jl
@@ -14,7 +14,7 @@ Also beware that it is an untyped, and unforgiving `printf` implementation. Type
 to match, eg. printing a 64-bit Julia integer requires the `%ld` formatting string.
 """
 macro cuprintf(fmt::String, args...)
-    fmt_val = Val{Symbol(fmt)}()
+    fmt_val = Val(Symbol(fmt))
     return :(_cuprintf($fmt_val, $(map(esc, args)...)))
 end
 

--- a/src/device/intrinsics/warp_shuffle.jl
+++ b/src/device/intrinsics/warp_shuffle.jl
@@ -141,16 +141,16 @@ end
 
 # aggregates (recurse into fields)
 
-@generated function shuffle_aggregate(op::Function, val::T, args...) where T
+@generated function shuffle_aggregate(op::Function, val, args...)
     ex = quote
         Base.@_inline_meta
     end
 
-    fields = fieldnames(T)
+    fields = fieldnames(val)
     if isempty(fields)
         push!(ex.args, :( shuffle_primitive(op, val, args...) ))
     else
-        ctor = Expr(:new, T)
+        ctor = Expr(:new, val)
         for field in fields
             push!(ctor.args, :( shuffle_aggregate(op, getfield(val, $(QuoteNode(field))),
                                                   args...) ))

--- a/src/device/intrinsics/warp_shuffle.jl
+++ b/src/device/intrinsics/warp_shuffle.jl
@@ -55,10 +55,10 @@ end
 
 for name in ["_up", "_down", "_xor", ""]
     fname = Symbol("shfl$name")
-    @eval @inline $fname(src, args...) = recurse_invocation($fname, src, args...)
+    @eval @inline $fname(src, args...) = recurse_value_invocation($fname, src, args...)
 
     fname_sync = Symbol("$(fname)_sync")
-    @eval @inline $fname_sync(src, args...) = recurse_invocation($fname, src, args...)
+    @eval @inline $fname_sync(src, args...) = recurse_value_invocation($fname, src, args...)
 end
 
 

--- a/src/device/intrinsics/warp_shuffle.jl
+++ b/src/device/intrinsics/warp_shuffle.jl
@@ -8,7 +8,7 @@
 const ws = Int32(32)
 
 
-# single-word primitives
+# primitive intrinsics
 
 # NOTE: CUDA C disagrees with PTX on how shuffles are called
 for (name, mode, mask) in (("_up",   :up,   UInt32(0x00)),
@@ -51,125 +51,14 @@ for (name, mode, mask) in (("_up",   :up,   UInt32(0x00)),
 end
 
 
-# multi-word primitives (recurse into words)
-
-## extract a word from a value
-@generated function extract_word(val, ::Val{i}) where {i}
-    T_int32 = LLVM.Int32Type(jlctx[])
-
-    bytes = Core.sizeof(val)
-    T_val = convert(LLVMType, val)
-    T_int = LLVM.IntType(8*bytes, jlctx[])
-
-    # create function
-    llvm_f, _ = create_function(T_int32, [T_val])
-    mod = LLVM.parent(llvm_f)
-
-    # generate IR
-    Builder(jlctx[]) do builder
-        entry = BasicBlock(llvm_f, "entry", jlctx[])
-        position!(builder, entry)
-
-        equiv = bitcast!(builder, parameters(llvm_f)[1], T_int)
-        shifted = lshr!(builder, equiv, LLVM.ConstantInt(T_int, 32*(i-1)))
-        # extracted = and!(builder, shifted, 2^32-1)
-        extracted = trunc!(builder, shifted, T_int32, "word$i")
-
-        ret!(builder, extracted)
-    end
-
-    call_function(llvm_f, UInt32, Tuple{val}, :( (val,) ))
-end
-
-## insert a word into a value
-@generated function insert_word(val, word::UInt32, ::Val{i}) where {i}
-    T_int32 = LLVM.Int32Type(jlctx[])
-
-    bytes = Core.sizeof(val)
-    T_val = convert(LLVMType, val)
-    T_int = LLVM.IntType(8*bytes, jlctx[])
-
-    # create function
-    llvm_f, _ = create_function(T_val, [T_val, T_int32])
-    mod = LLVM.parent(llvm_f)
-
-    # generate IR
-    Builder(jlctx[]) do builder
-        entry = BasicBlock(llvm_f, "entry", jlctx[])
-        position!(builder, entry)
-
-        equiv = bitcast!(builder, parameters(llvm_f)[1], T_int)
-        ext = zext!(builder, parameters(llvm_f)[2], T_int)
-        shifted = shl!(builder, ext, LLVM.ConstantInt(T_int, 32*(i-1)))
-        inserted = or!(builder, equiv, shifted)
-        orig = bitcast!(builder, inserted, T_val)
-
-        ret!(builder, orig)
-    end
-
-    call_function(llvm_f, val, Tuple{val, UInt32}, :( (val, word) ))
-end
-
-@generated function shuffle_primitive(op::Function, val, args...)
-    ex = quote
-        Base.@_inline_meta
-    end
-
-    # disassemble into words
-    words = Symbol[]
-    for i in 1:Core.sizeof(val)÷4
-        word = Symbol("word$i")
-        push!(ex.args, :( $word = extract_word(val, Val{$i}()) ))
-        push!(words, word)
-    end
-
-    # shuffle
-    for word in words
-        push!(ex.args, :( $word = op($word, args...)) )
-    end
-
-    # reassemble
-    push!(ex.args, :( out = zero(val) ))
-    for (i,word) in enumerate(words)
-        push!(ex.args, :( out = insert_word(out, $word, Val{$i}()) ))
-    end
-
-    push!(ex.args, :( out ))
-    return ex
-end
-
-
-# aggregates (recurse into fields)
-
-@generated function shuffle_aggregate(op::Function, val, args...)
-    ex = quote
-        Base.@_inline_meta
-    end
-
-    fields = fieldnames(val)
-    if isempty(fields)
-        push!(ex.args, :( shuffle_primitive(op, val, args...) ))
-    else
-        ctor = Expr(:new, val)
-        for field in fields
-            push!(ctor.args, :( shuffle_aggregate(op, getfield(val, $(QuoteNode(field))),
-                                                  args...) ))
-        end
-        push!(ex.args, ctor)
-    end
-
-    return ex
-end
-
-
-# entry-point functions
+# wide and aggregate intrinsics
 
 for name in ["_up", "_down", "_xor", ""]
     fname = Symbol("shfl$name")
-    @eval @inline $fname(src, args...) = shuffle_aggregate($fname, src, args...)
+    @eval @inline $fname(src, args...) = recurse_invocation($fname, src, args...)
 
     fname_sync = Symbol("$(fname)_sync")
-    @eval @inline $fname_sync(src, args...) = shuffle_aggregate($fname, src, args...)
+    @eval @inline $fname_sync(src, args...) = recurse_invocation($fname, src, args...)
 end
 
 

--- a/src/pointer.jl
+++ b/src/pointer.jl
@@ -238,5 +238,5 @@ const CachedLoadPointers = Union{Tuple(DevicePtr{T,AS.Global}
 end
 
 @inline function unsafe_cached_load(p::DevicePtr{T,AS.Global}, args...) where {T}
-    split_pointer_invocation(unsafe_cached_load, p, CachedLoadPointers, args...)
+    recurse_pointer_invocation(unsafe_cached_load, p, CachedLoadPointers, args...)
 end

--- a/src/pointer.jl
+++ b/src/pointer.jl
@@ -172,9 +172,14 @@ end
 # TODO: aren't there more caching options?
 #       https://devtalk.nvidia.com/default/topic/938474/8-0-rc-has-new-global-load-intrinsics-with-explicit-cache-modifiers/
 
+# operand types supported by llvm.nvvm.ldg.global
 const CachedLoadOperands = Union{UInt8, UInt16, UInt32, UInt64,
                                  Int8, Int16, Int32, Int64,
                                  Float32, Float64}
+
+# containing DevicePtr types
+const CachedLoadPointers = Union{Tuple(DevicePtr{T,AS.Global}
+                                 for T in Base.uniontypes(CachedLoadOperands))...}
 
 @generated function unsafe_cached_load(p::DevicePtr{T,AS.Global}, i::Integer=1,
                                        ::Val{align}=Val(1)) where
@@ -234,5 +239,5 @@ const CachedLoadOperands = Union{UInt8, UInt16, UInt32, UInt64,
 end
 
 @inline function unsafe_cached_load(p::DevicePtr{T,AS.Global}, args...) where {T}
-    split_pointer_invocation(unsafe_cached_load, p, DevicePtr{UInt32,AS.Global}, args...)
+    split_pointer_invocation(unsafe_cached_load, p, CachedLoadPointers, args...)
 end

--- a/src/pointer.jl
+++ b/src/pointer.jl
@@ -98,8 +98,8 @@ Base.convert(::Type{Int}, ::Type{AS.Shared})   = 3
 Base.convert(::Type{Int}, ::Type{AS.Constant}) = 4
 Base.convert(::Type{Int}, ::Type{AS.Local})    = 5
 
-@generated function Base.unsafe_load(p::DevicePtr{T,A}, i::I=1,
-                                     ::Type{Val{align}}=Val{1}) where {T,A,align,I<:Integer}
+@generated function Base.unsafe_load(p::DevicePtr{T,A}, i::Integer=1,
+                                     ::Type{Val{align}}=Val(1)) where {T,A,align}
     eltyp = convert(LLVMType, T)
 
     T_int = convert(LLVMType, Int)
@@ -129,11 +129,11 @@ Base.convert(::Type{Int}, ::Type{AS.Local})    = 5
         ret!(builder, val)
     end
 
-    call_function(llvm_f, T, Tuple{Ptr{T}, Int}, :((pointer(p), Int(i-one(I)))))
+    call_function(llvm_f, T, Tuple{Ptr{T}, Int}, :((pointer(p), Int(i-one(i)))))
 end
 
-@generated function Base.unsafe_store!(p::DevicePtr{T,A}, x, i::I=1,
-                                       ::Type{Val{align}}=Val{1}) where {T,A,align,I<:Integer}
+@generated function Base.unsafe_store!(p::DevicePtr{T,A}, x, i::Integer=1,
+                                       ::Type{Val{align}}=Val(1)) where {T,A,align}
     eltyp = convert(LLVMType, T)
 
     T_int = convert(LLVMType, Int)
@@ -164,7 +164,7 @@ end
         ret!(builder)
     end
 
-    call_function(llvm_f, Cvoid, Tuple{Ptr{T}, T, Int}, :((pointer(p), convert(T,x), Int(i-one(I)))))
+    call_function(llvm_f, Cvoid, Tuple{Ptr{T}, T, Int}, :((pointer(p), convert(T,x), Int(i-one(i)))))
 end
 
 ## loading through the texture cache
@@ -172,9 +172,9 @@ end
 # TODO: aren't there more caching options?
 #       https://devtalk.nvidia.com/default/topic/938474/8-0-rc-has-new-global-load-intrinsics-with-explicit-cache-modifiers/
 
-@generated function unsafe_cached_load(p::DevicePtr{T,AS.Global}, i::I=1,
-                                       ::Type{Val{align}}=Val{1}) where
-                                      {align,I<:Integer,T<:Union{Integer,AbstractFloat}}
+@generated function unsafe_cached_load(p::DevicePtr{T,AS.Global}, i::Integer=1,
+                                       ::Type{Val{align}}=Val(1)) where
+                                      {align,T<:Union{Integer,AbstractFloat}}
     # NOTE: we can't `ccall(..., llvmcall)`, because
     #       1) Julia passes pointer arguments as plain integers
     #       2) we need to addrspacecast the pointer argument
@@ -226,7 +226,7 @@ end
         ret!(builder, val)
     end
 
-    call_function(llvm_f, T, Tuple{Ptr{T}, Int}, :((pointer(p), Int(i-one(I)))))
+    call_function(llvm_f, T, Tuple{Ptr{T}, Int}, :((pointer(p), Int(i-one(i)))))
 end
 
 @inline function unsafe_cached_load(p::DevicePtr{T,AS.Global}, args...) where {T}

--- a/src/pointer.jl
+++ b/src/pointer.jl
@@ -99,7 +99,7 @@ Base.convert(::Type{Int}, ::Type{AS.Constant}) = 4
 Base.convert(::Type{Int}, ::Type{AS.Local})    = 5
 
 @generated function Base.unsafe_load(p::DevicePtr{T,A}, i::Integer=1,
-                                     ::Type{Val{align}}=Val{1}) where {T,A,align}
+                                     ::Val{align}=Val(1)) where {T,A,align}
     eltyp = convert(LLVMType, T)
 
     T_int = convert(LLVMType, Int)
@@ -133,7 +133,7 @@ Base.convert(::Type{Int}, ::Type{AS.Local})    = 5
 end
 
 @generated function Base.unsafe_store!(p::DevicePtr{T,A}, x, i::Integer=1,
-                                       ::Type{Val{align}}=Val{1}) where {T,A,align}
+                                       ::Val{align}=Val(1)) where {T,A,align}
     eltyp = convert(LLVMType, T)
 
     T_int = convert(LLVMType, Int)
@@ -180,7 +180,7 @@ const UncachedOperands = Union{Int8,  UInt8,
                                Float64}
 
 @generated function unsafe_cached_load(p::DevicePtr{T,AS.Global}, i::Integer=1,
-                                       ::Type{Val{align}}=Val{1}) where
+                                       ::Val{align}=Val(1)) where
                                       {T<:UncachedOperands,align}
     # NOTE: we can't `ccall(..., llvmcall)`, because
     #       1) Julia passes pointer arguments as plain integers

--- a/src/pointer.jl
+++ b/src/pointer.jl
@@ -172,16 +172,13 @@ end
 # TODO: aren't there more caching options?
 #       https://devtalk.nvidia.com/default/topic/938474/8-0-rc-has-new-global-load-intrinsics-with-explicit-cache-modifiers/
 
-const UncachedOperands = Union{Int8,  UInt8,
-                               Int16, UInt16,
-                               Int32, UInt32,
-                               Int64, UInt64,
-                               Float32,
-                               Float64}
+const CachedLoadOperands = Union{UInt8, UInt16, UInt32, UInt64,
+                                 Int8, Int16, Int32, Int64,
+                                 Float32, Float64}
 
 @generated function unsafe_cached_load(p::DevicePtr{T,AS.Global}, i::Integer=1,
                                        ::Val{align}=Val(1)) where
-                                      {T<:UncachedOperands,align}
+                                      {T<:CachedLoadOperands,align}
     # NOTE: we can't `ccall(..., llvmcall)`, because
     #       1) Julia passes pointer arguments as plain integers
     #       2) we need to addrspacecast the pointer argument
@@ -236,7 +233,6 @@ const UncachedOperands = Union{Int8,  UInt8,
     call_function(llvm_f, T, Tuple{Ptr{T}, Int}, :((pointer(p), Int(i-one(i)))))
 end
 
-# TODO: extend the recurse/split_invocation infrastructure to work with pointers
-# @inline function unsafe_cached_load(p::DevicePtr{T,AS.Global}, args...) where {T}
-#     recurse_invocation(unsafe_cached_load, p, args...)
-# end
+@inline function unsafe_cached_load(p::DevicePtr{T,AS.Global}, args...) where {T}
+    split_pointer_invocation(unsafe_cached_load, p, DevicePtr{UInt32,AS.Global}, args...)
+end

--- a/src/pointer.jl
+++ b/src/pointer.jl
@@ -99,7 +99,7 @@ Base.convert(::Type{Int}, ::Type{AS.Constant}) = 4
 Base.convert(::Type{Int}, ::Type{AS.Local})    = 5
 
 @generated function Base.unsafe_load(p::DevicePtr{T,A}, i::Integer=1,
-                                     ::Type{Val{align}}=Val(1)) where {T,A,align}
+                                     ::Type{Val{align}}=Val{1}) where {T,A,align}
     eltyp = convert(LLVMType, T)
 
     T_int = convert(LLVMType, Int)
@@ -133,7 +133,7 @@ Base.convert(::Type{Int}, ::Type{AS.Local})    = 5
 end
 
 @generated function Base.unsafe_store!(p::DevicePtr{T,A}, x, i::Integer=1,
-                                       ::Type{Val{align}}=Val(1)) where {T,A,align}
+                                       ::Type{Val{align}}=Val{1}) where {T,A,align}
     eltyp = convert(LLVMType, T)
 
     T_int = convert(LLVMType, Int)
@@ -173,7 +173,7 @@ end
 #       https://devtalk.nvidia.com/default/topic/938474/8-0-rc-has-new-global-load-intrinsics-with-explicit-cache-modifiers/
 
 @generated function unsafe_cached_load(p::DevicePtr{T,AS.Global}, i::Integer=1,
-                                       ::Type{Val{align}}=Val(1)) where
+                                       ::Type{Val{align}}=Val{1}) where
                                       {align,T<:Union{Integer,AbstractFloat}}
     # NOTE: we can't `ccall(..., llvmcall)`, because
     #       1) Julia passes pointer arguments as plain integers

--- a/src/pointer.jl
+++ b/src/pointer.jl
@@ -169,8 +169,7 @@ end
 
 ## loading through the texture cache
 
-# TODO: aren't there more caching options?
-#       https://devtalk.nvidia.com/default/topic/938474/8-0-rc-has-new-global-load-intrinsics-with-explicit-cache-modifiers/
+# NOTE: CUDA 8.0 supports more caching modifiers, but those aren't supported by LLVM yet
 
 # operand types supported by llvm.nvvm.ldg.global
 const CachedLoadOperands = Union{UInt8, UInt16, UInt32, UInt64,

--- a/test/array.jl
+++ b/test/array.jl
@@ -108,14 +108,14 @@ end
 
     # NOTE: these tests verify that bounds checking is _disabled_ (see #4)
 
-    ir = sprint(io->CUDAnative.code_llvm(io, array_oob_1d, (CuDeviceArray{Int,1,AS.Global},)))
+    ir = sprint(io->CUDAnative.code_llvm(io, array_oob_1d, (CuDeviceArray{Int,1,AS.Global,false},)))
     @test !contains(ir, "trap")
 
     @eval function array_oob_2d(array)
         return array[1, 1]
     end
 
-    ir = sprint(io->CUDAnative.code_llvm(io, array_oob_2d, (CuDeviceArray{Int,2,AS.Global},)))
+    ir = sprint(io->CUDAnative.code_llvm(io, array_oob_2d, (CuDeviceArray{Int,2,AS.Global,false},)))
     @test !contains(ir, "trap")
 end
 

--- a/test/array.jl
+++ b/test/array.jl
@@ -1,7 +1,5 @@
 @testset "device arrays" begin
 
-############################################################################################
-
 @testset "constructors" begin
     # inner constructors
     let
@@ -49,10 +47,6 @@
     end
 end
 
-
-
-############################################################################################
-
 @testset "basics" begin     # argument passing, get and setindex, length
     dims = (16, 16)
     len = prod(dims)
@@ -99,8 +93,6 @@ end
     @test sum(input) ≈ output[1]
 end
 
-############################################################################################
-
 @testset "bounds checking" begin
     @eval function array_oob_1d(array)
         return array[1]
@@ -118,10 +110,6 @@ end
     ir = sprint(io->CUDAnative.code_llvm(io, array_oob_2d, (CuDeviceArray{Int,2,AS.Global,false},)))
     @test !contains(ir, "trap")
 end
-
-
-
-############################################################################################
 
 @testset "views" begin
     @eval function array_view(array)
@@ -147,9 +135,6 @@ end
     @test array == Array(array_dev)
 end
 
-############################################################################################
-
-
 @testset "bug: non-Int index to unsafe_load" begin
     @eval function array_load_index(a)
         return a[UInt64(1)]
@@ -160,6 +145,23 @@ end
     dp = CUDAnative.DevicePtr(p)
     da = CUDAnative.CuDeviceArray(1, dp)
     array_load_index(da)
+end
+
+@testset "cached access" begin
+    @eval function array_cached_load(a, b, i)
+        b[i] = Cached(a)[i]
+        return nothing
+    end
+
+    buf = IOBuffer()
+
+    a = CuTestArray([0])
+    b = CuTestArray([0])
+    @device_code_ptx io=buf @cuda array_cached_load(a, b, 1)
+    @test Array(a) == Array(b)
+
+    asm = String(buf)
+    @test contains(asm, "ld.global.nc")
 end
 
 end

--- a/test/array.jl
+++ b/test/array.jl
@@ -1,7 +1,5 @@
 @testset "device arrays" begin
 
-############################################################################################
-
 @testset "constructors" begin
     # inner constructors
     let
@@ -49,10 +47,6 @@
     end
 end
 
-
-
-############################################################################################
-
 @testset "basics" begin     # argument passing, get and setindex, length
     dims = (16, 16)
     len = prod(dims)
@@ -99,8 +93,6 @@ end
     @test sum(input) ≈ output[1]
 end
 
-############################################################################################
-
 @testset "bounds checking" begin
     @eval function array_oob_1d(array)
         return array[1]
@@ -118,10 +110,6 @@ end
     ir = sprint(io->CUDAnative.code_llvm(io, array_oob_2d, (CuDeviceArray{Int,2,AS.Global},)))
     @test !contains(ir, "trap")
 end
-
-
-
-############################################################################################
 
 @testset "views" begin
     @eval function array_view(array)
@@ -147,9 +135,6 @@ end
     @test array == Array(array_dev)
 end
 
-############################################################################################
-
-
 @testset "bug: non-Int index to unsafe_load" begin
     @eval function array_load_index(a)
         return a[UInt64(1)]
@@ -160,6 +145,23 @@ end
     dp = CUDAnative.DevicePtr(p)
     da = CUDAnative.CuDeviceArray(1, dp)
     array_load_index(da)
+end
+
+@testset "ldg" begin
+    @eval function array_cached_load(a, b, i)
+        b[i] = ldg(a, i)
+        return nothing
+    end
+
+    buf = IOBuffer()
+
+    a = CuTestArray([0])
+    b = CuTestArray([0])
+    @device_code_ptx io=buf @cuda array_cached_load(a, b, 1)
+    @test Array(a) == Array(b)
+
+    asm = String(buf)
+    @test contains(asm, "ld.global.nc")
 end
 
 end

--- a/test/codegen.jl
+++ b/test/codegen.jl
@@ -127,7 +127,7 @@ end
 
     @eval llvm_D32593(arr) = arr[1].foo
 
-    CUDAnative.code_llvm(DevNull, llvm_D32593, Tuple{CuDeviceVector{llvm_D32593_struct,AS.Global,false}})
+    CUDAnative.code_llvm(DevNull, llvm_D32593, Tuple{CuDeviceVector{llvm_D32593_struct,AS.Global}})
 end
 
 @testset "julia calling convention" begin

--- a/test/codegen.jl
+++ b/test/codegen.jl
@@ -127,7 +127,7 @@ end
 
     @eval llvm_D32593(arr) = arr[1].foo
 
-    CUDAnative.code_llvm(DevNull, llvm_D32593, Tuple{CuDeviceVector{llvm_D32593_struct,AS.Global}})
+    CUDAnative.code_llvm(DevNull, llvm_D32593, Tuple{CuDeviceVector{llvm_D32593_struct,AS.Global,false}})
 end
 
 @testset "julia calling convention" begin

--- a/test/pointer_device.jl
+++ b/test/pointer_device.jl
@@ -1,0 +1,25 @@
+@testset "pointer (on device)" begin
+
+@testset "unsafe_load & unsafe_store!" begin
+
+@testset for T in (Int8, UInt16, Int32, UInt32, Int64, UInt64,
+                   Float32,Float64),
+             cached in (false, true)
+    d_a = Mem.upload(ones(T))
+    d_b = Mem.upload(zeros(T))
+
+    ptr_a = CUDAnative.DevicePtr{T,AS.Global}(Base.unsafe_convert(Ptr{T}, d_a))
+    ptr_b = CUDAnative.DevicePtr{T,AS.Global}(Base.unsafe_convert(Ptr{T}, d_b))
+
+    @test Mem.download(T, d_a) != Mem.download(T, d_b)
+    if cached
+        @on_device Base.unsafe_store!($ptr_b, CUDAnative.unsafe_cached_load($ptr_a))
+    else
+        @on_device Base.unsafe_store!($ptr_b, CUDAnative.unsafe_load($ptr_a))
+    end
+    @test Mem.download(T, d_a) == Mem.download(T, d_b)
+end
+
+end
+
+end

--- a/test/pointer_device.jl
+++ b/test/pointer_device.jl
@@ -2,7 +2,7 @@
 
 @testset "unsafe_load & unsafe_store!" begin
 
-@testset for T in (Int8, UInt16, Int32, UInt32, Int64, UInt64,
+@testset for T in (Int8, UInt16, Int32, UInt32, Int64, UInt64, Int128,
                    Float32,Float64),
              cached in (false, true)
     d_a = Mem.upload(ones(T))

--- a/test/pointer_device.jl
+++ b/test/pointer_device.jl
@@ -2,8 +2,16 @@
 
 @testset "unsafe_load & unsafe_store!" begin
 
+@eval struct LoadableStruct
+    a::Int64
+    b::UInt8
+end
+Base.one(::Type{LoadableStruct}) = LoadableStruct(1,1)
+Base.zero(::Type{LoadableStruct}) = LoadableStruct(0,0)
+
 @testset for T in (Int8, UInt16, Int32, UInt32, Int64, UInt64, Int128,
-                   Float32,Float64),
+                   Float32,Float64,
+                   LoadableStruct),
              cached in (false, true)
     d_a = Mem.upload(ones(T))
     d_b = Mem.upload(zeros(T))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,6 +35,7 @@ if CUDAnative.configured
         else
             include("codegen_device.jl")
             include("execution.jl")
+            include("pointer_device.jl")
             include("array.jl")
             include("intrinsics.jl")
 


### PR DESCRIPTION
This branch packs a couple of improvements, as well as initial support for `__ldg` for loading values through the texture cache. See the CUDA docs for more info, but in short: the texture cache is faster than the global cache (which caches global values automatically), but it is a non-coherent cache which implies that the array should be read-only for the entire duration of the kernel.

This PR only features the compiler support, no real front-end yet. Ideas/suggestions? Keyword argument to `getindex`? Constness typevar for CuArray/CuDeviceArray? Even though we'd need proper alias analysis (ref JuliaLang/julia#25890), this should already be usable in eg. non-mutating `broadcast`.

cc @vchuravy @MikeInnes