### PR TITLE
Don't require ptxas or cuobjdump.

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -127,12 +127,12 @@ function main()
     @debug("CUDAnative support", targets=config[:target_support], isas=config[:ptx_support])
 
     # discover other CUDA toolkit artifacts
+    ## required
     config[:libdevice] = find_libdevice(config[:target_support], toolkit_dirs)
     config[:libdevice] == nothing && error("Available CUDA toolchain does not provide libdevice")
+    ## optional
     config[:cuobjdump] = find_cuda_binary("cuobjdump", toolkit_dirs)
-    config[:cuobjdump] == nothing && error("Available CUDA toolchain does not provide cuobjdump")
     config[:ptxas] = find_cuda_binary("ptxas", toolkit_dirs)
-    config[:ptxas] == nothing && error("Available CUDA toolchain does not provide ptxas")
 
     config[:configured] = true
 

--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -92,6 +92,10 @@ See also: [`@device_code_sass`](@ref)
 """
 function code_sass(io::IO, @nospecialize(func::Core.Function), @nospecialize(types=Tuple);
                    cap::VersionNumber=current_capability(), kwargs...)
+    if ptxas === nothing || cuobjdump === nothing
+        error("Your CUDA installation does not provide ptxas or cuobjdump, both of which are required for code_sass")
+    end
+
     tt = Base.to_tuple_type(types)
     check_invocation(func, tt; kernel=true)
 


### PR DESCRIPTION
cc @SimonDanisch 

At this point, if we were to ship `libdevice` we wouldn't even require the CUDA toolkit at all, just the driver. But then we'd be required to prompt the EULA, etc, so I don't think I'll bother with that.