### PR TITLE
Support for passing non-isbits values, as long as they are unused.

### DIFF
--- a/test/codegen.jl
+++ b/test/codegen.jl
@@ -133,9 +133,6 @@ end
 @testset "julia calling convention" begin
     @eval codegen_specsig_va(Is...) = nothing
     @test_throws ArgumentError CUDAnative.code_llvm(devnull, codegen_specsig_va, Tuple{})
-
-    @eval codegen_specsig_nonleaf(x) = nothing
-    @test_throws ArgumentError CUDAnative.code_llvm(devnull, codegen_specsig_nonleaf, Tuple{Real})
 end
 
 end

--- a/test/execution.jl
+++ b/test/execution.jl
@@ -292,6 +292,18 @@ end
     @test Mem.download(Int, buf) == [2]
 end
 
+
+@testset "non-isbits arguments" begin
+    @eval exec_pass_nonbits_unused(T, i) = (sink(i); return)
+    @cuda exec_pass_nonbits_unused(Int, 1)
+
+    @eval exec_pass_nonbits_specialized(T, i) = (sink(unsafe_trunc(T,i)); return)
+    @cuda exec_pass_nonbits_specialized(Int, 1.)
+
+    @eval exec_pass_nonbits_used(i) = (sink(unsafe_trunc(Int,i)); return)
+    @test_throws ArgumentError @cuda exec_pass_nonbits_used(big"1")
+end
+
 end
 
 ############################################################################################


### PR DESCRIPTION
Implements #163. Seems kinda insane.

```
   _       _ _(_)_     |  A fresh approach to technical computing
  (_)     | (_) (_)    |  Documentation: https://docs.julialang.org
   _ _   _| |_  __ _   |  Type "?help" for help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 0.7.0-DEV.4473 (2018-03-06 05:55 UTC)
 _/ |\__'_|_|_|\__'_|  |  Commit 2f826b55d6* (10 days old master)
|__/                   |  x86_64-unknown-linux-gnu

julia> using CUDAnative, CUDAdrv

julia> @device_code_llvm @cuda ((T, i)->(@cuprintf("Got %ld\n", unsafe_trunc(T, i)); return))(Int, 1.)

define void @ptxcall__6_1(%jl_value_t addrspace(10)*, double) local_unnamed_addr {
entry:
  %args.i.i = alloca %vprintf_args, align 8
  %2 = fptosi double %1 to i64, !dbg !5
  %3 = bitcast %vprintf_args* %args.i.i to i8*, !dbg !11
  call void @llvm.lifetime.start(i64 8, i8* %3), !dbg !11
  %4 = getelementptr inbounds %vprintf_args, %vprintf_args* %args.i.i, i64 0, i32 0, !dbg !11
  store i64 %2, i64* %4, align 8, !dbg !11
  %5 = call i32 @vprintf(i8* getelementptr inbounds ([9 x i8], [9 x i8]* @0, i64 0, i64 0), i8* %3), !dbg !11
  call void @llvm.lifetime.end(i64 8, i8* %3), !dbg !11
  ret void
}

julia> synchronize()
Got 1
```