### PR TITLE
make scan example work for Vector

### DIFF
--- a/examples/scan.jl
+++ b/examples/scan.jl
@@ -67,7 +67,7 @@ cpu_a = copy(a)
 cpu_accumulate!(+, cpu_a)
 
 gpu_a = CuArray(a)
-@cuda blocks=cols threads=rows shmem=cols*rows*sizeof(eltype(a)) gpu_accumulate!(+, gpu_a)
+@cuda blocks=cols threads=rows shmem=2*rows*sizeof(eltype(a)) gpu_accumulate!(+, gpu_a)
 
 using Test
 


### PR DESCRIPTION
@dpsanders and I needed `accumulate!` for Vectors today and we
run into the issue that the ammount of shmem requested depends on
`cols * rows`, wheras the kernel only needs `2 * rows`