### PR TITLE
Attach range metadata to indexing intrinsics.

### DIFF
--- a/src/device/intrinsics/indexing.jl
+++ b/src/device/intrinsics/indexing.jl
@@ -4,22 +4,58 @@ export
     threadIdx, blockDim, blockIdx, gridDim,
     warpsize
 
+@generated function _index(::Val{name}, ::Val{range}) where {name, range}
+    T_int32 = LLVM.Int32Type(jlctx[])
+
+    # create function
+    llvm_f, _ = create_function(T_int32)
+    mod = LLVM.parent(llvm_f)
+
+    # generate IR
+    Builder(jlctx[]) do builder
+        entry = BasicBlock(llvm_f, "entry", jlctx[])
+        position!(builder, entry)
+
+        # call the indexing intrinsic
+        intr_typ = LLVM.FunctionType(T_int32)
+        intr = LLVM.Function(mod, "llvm.nvvm.read.ptx.sreg.$name", intr_typ)
+        idx = call!(builder, intr)
+
+        # attach range metadata
+        range_metadata = MDNode([ConstantInt(Int32(range.start), jlctx[]),
+                                 ConstantInt(Int32(range.stop), jlctx[])],
+                                jlctx[])
+        metadata(idx)[LLVM.MD_range] = range_metadata
+
+        ret!(builder, idx)
+    end
+
+    call_function(llvm_f, UInt32)
+end
+
 for dim in (:x, :y, :z)
+    # TODO: range per intrinsic & device
+    range = 0:typemax(Int32)
+
     # Thread index
     fn = Symbol("threadIdx_$dim")
-    @eval @inline $fn() = (ccall($"llvm.nvvm.read.ptx.sreg.tid.$dim", llvmcall, UInt32, ()))+UInt32(1)
+    intr = Symbol("tid.$dim")
+    @eval @inline $fn() = _index($(Val(intr)), $(Val(range))) + UInt32(1)
 
     # Block size (#threads per block)
     fn = Symbol("blockDim_$dim")
-    @eval @inline $fn() =  ccall($"llvm.nvvm.read.ptx.sreg.ntid.$dim", llvmcall, UInt32, ())
+    intr = Symbol("ntid.$dim")
+    @eval @inline $fn() = _index($(Val(intr)), $(Val(range)))
 
     # Block index
     fn = Symbol("blockIdx_$dim")
-    @eval @inline $fn() = (ccall($"llvm.nvvm.read.ptx.sreg.ctaid.$dim", llvmcall, UInt32, ()))+UInt32(1)
+    intr = Symbol("ctaid.$dim")
+    @eval @inline $fn() = _index($(Val(intr)), $(Val(range))) + UInt32(1)
 
     # Grid size (#blocks per grid)
     fn = Symbol("gridDim_$dim")
-    @eval @inline $fn() =  ccall($"llvm.nvvm.read.ptx.sreg.nctaid.$dim", llvmcall, UInt32, ())
+    intr = Symbol("nctaid.$dim")
+    @eval @inline $fn() = _index($(Val(intr)), $(Val(range)))
 end
 
 """

--- a/test/device/intrinsics.jl
+++ b/test/device/intrinsics.jl
@@ -2,6 +2,28 @@
 
 ############################################################################################
 
+@testset "indexing" begin
+    for dim in (:x, :y, :z)
+        @on_device threadIdx().$dim
+        @on_device blockDim().$dim
+        @on_device blockIdx().$dim
+        @on_device gridDim().$dim
+    end
+
+    if VERSION >= v"0.7.0-DEV.4901"
+        @testset "range metadata" begin
+            @eval codegen_indexing() = threadIdx().x
+            ir = sprint(io->CUDAnative.code_llvm(io, codegen_indexing, Tuple{}))
+
+            @test occursin(r"call .+ @llvm.nvvm.read.ptx.sreg.tid.x.+ !range", ir)
+        end
+    end
+end
+
+
+
+############################################################################################
+
 @testset "math" begin
     buf = CuTestArray(Float32[0])
 


### PR DESCRIPTION
ref https://github.com/JuliaGPU/CUDAnative.jl/pull/149#issuecomment-360989609 (cc @vchuravy)
requires https://github.com/JuliaLang/julia/pull/26844 for the metadata to survive

Not sure if LLVM uses this, but heck why not at least provide the information.
With contextual dispatch, we can make it even more accurate (ie. device-specific).