### PR TITLE
Use Int instead of 32-bit integers

### DIFF
--- a/src/device/array.jl
+++ b/src/device/array.jl
@@ -130,6 +130,6 @@ function Base.unsafe_view(A::CuDeviceVector{T}, I::Vararg{Base.ViewIndex,1}) whe
     return CuDeviceArray(len, ptr)
 end
 
-Base.start(x::CuDeviceArray) = Cuint(1)
-Base.next(x::CuDeviceArray, state::Cuint) = x[state], state + Cuint(1)
-Base.done(x::CuDeviceArray, state::Cuint) = state > length(x)
+Base.start(x::CuDeviceArray) = 1
+Base.next(x::CuDeviceArray, state::Int) = x[state], state + 1
+Base.done(x::CuDeviceArray, state::Int) = state > length(x)

--- a/src/device/intrinsics/indexing.jl
+++ b/src/device/intrinsics/indexing.jl
@@ -65,32 +65,32 @@ end
 
 Returns the dimensions of the grid.
 """
-@inline gridDim() =   CUDAdrv.CuDim3(gridDim_x(),   gridDim_y(),   gridDim_z())
+@inline gridDim() =   (x=gridDim_x(),   y=gridDim_y(),   z=gridDim_z())
 
 """
     blockIdx()::CuDim3
 
 Returns the block index within the grid.
 """
-@inline blockIdx() =  CUDAdrv.CuDim3(blockIdx_x(),  blockIdx_y(),  blockIdx_z())
+@inline blockIdx() =  (x=blockIdx_x(),  y=blockIdx_y(),  z=blockIdx_z())
 
 """
     blockDim()::CuDim3
 
 Returns the dimensions of the block.
 """
-@inline blockDim() =  CUDAdrv.CuDim3(blockDim_x(),  blockDim_y(),  blockDim_z())
+@inline blockDim() =  (x=blockDim_x(),  y=blockDim_y(),  z=blockDim_z())
 
 """
     threadIdx()::CuDim3
 
 Returns the thread index within the block. 
 """
-@inline threadIdx() = CUDAdrv.CuDim3(threadIdx_x(), threadIdx_y(), threadIdx_z())
+@inline threadIdx() = (x=threadIdx_x(), y=threadIdx_y(), z=threadIdx_z())
 
 """
     warpsize()::UInt32
 
 Returns the warp size (in threads).
 """
-@inline warpsize() = ccall("llvm.nvvm.read.ptx.sreg.warpsize", llvmcall, UInt32, ())
+@inline warpsize() = Int(ccall("llvm.nvvm.read.ptx.sreg.warpsize", llvmcall, UInt32, ()))

--- a/src/device/intrinsics/indexing.jl
+++ b/src/device/intrinsics/indexing.jl
@@ -42,22 +42,22 @@ for dim in (:x, :y, :z)
     # Thread index
     fn = Symbol("threadIdx_$dim")
     intr = Symbol("tid.$dim")
-    @eval @inline $fn() = _index($(Val(intr)), $(Val(0:max_block_size[dim]-1))) + UInt32(1)
+    @eval @inline $fn() = Int(_index($(Val(intr)), $(Val(0:max_block_size[dim]-1)))) + 1
 
     # Block size (#threads per block)
     fn = Symbol("blockDim_$dim")
     intr = Symbol("ntid.$dim")
-    @eval @inline $fn() = _index($(Val(intr)), $(Val(1:max_block_size[dim])))
+    @eval @inline $fn() = Int(_index($(Val(intr)), $(Val(1:max_block_size[dim]))))
 
     # Block index
     fn = Symbol("blockIdx_$dim")
     intr = Symbol("ctaid.$dim")
-    @eval @inline $fn() = _index($(Val(intr)), $(Val(0:max_grid_size[dim]-1))) + UInt32(1)
+    @eval @inline $fn() = Int(_index($(Val(intr)), $(Val(0:max_grid_size[dim]-1)))) + 1
 
     # Grid size (#blocks per grid)
     fn = Symbol("gridDim_$dim")
     intr = Symbol("nctaid.$dim")
-    @eval @inline $fn() = _index($(Val(intr)), $(Val(1:max_grid_size[dim])))
+    @eval @inline $fn() = Int(_index($(Val(intr)), $(Val(1:max_grid_size[dim]))))
 end
 
 """

--- a/src/device/intrinsics/warp_shuffle.jl
+++ b/src/device/intrinsics/warp_shuffle.jl
@@ -10,18 +10,16 @@ const ws = Int32(32)
 
 # primitive intrinsics
 
+# "two packed values specifying a mask for logically splitting warps into sub-segments
+# and an upper bound for clamping the source lane index"
+@inline pack(width::UInt32, mask::UInt32)::UInt32 = (convert(UInt32, ws - width) << 8) | mask
+
 # NOTE: CUDA C disagrees with PTX on how shuffles are called
 for (name, mode, mask) in (("_up",   :up,   UInt32(0x00)),
                            ("_down", :down, UInt32(0x1f)),
                            ("_xor",  :bfly, UInt32(0x1f)),
                            ("",      :idx,  UInt32(0x1f)))
     fname = Symbol("shfl$name")
-
-    # FIXME: usage of unsafe_trunc...
-
-    # "two packed values specifying a mask for logically splitting warps into sub-segments
-    # and an upper bound for clamping the source lane index"
-    pack_expr = :(((convert(UInt32, $ws - width)) << 8) | $mask)
 
     if cuda_driver_version >= v"9.0" && v"6.0" in ptx_support
         instruction = Symbol("shfl.sync.$mode.b32")
@@ -32,12 +30,17 @@ for (name, mode, mask) in (("_up",   :up,   UInt32(0x00)),
         @eval begin
             export $fname_sync, $fname
 
-            @inline $fname_sync(val::UInt32, src::Integer, width::Integer=$ws,
+            @inline $fname_sync(val::UInt32, src::UInt32, width::UInt32=$ws,
                                 threadmask::UInt32=0xffffffff) =
                 @asmcall($"$instruction \$0, \$1, \$2, \$3, \$4;", "=r,r,r,r,r", true,
                          UInt32, NTuple{4,UInt32},
-                         val, unsafe_trunc(UInt32, src), unsafe_trunc(UInt32, $pack_expr),
-                         threadmask)
+                         val, src, pack(width, $mask), threadmask)
+
+            # FIXME: replace this with a checked conversion once we have exceptions
+            @inline $fname_sync(val::UInt32, src::Integer, width::Integer=$ws,
+                                threadmask::UInt32=0xffffffff) =
+                $fname_sync(val, unsafe_trunc(UInt32, src), unsafe_trunc(UInt32, width),
+                            threadmask)
 
             @inline $fname(val::UInt32, src::Integer, width::Integer=$ws) =
                 $fname_sync(val, src, width)
@@ -47,10 +50,14 @@ for (name, mode, mask) in (("_up",   :up,   UInt32(0x00)),
 
         @eval begin
             export $fname
-            @inline $fname(val::UInt32, src::Integer, width::Integer=$ws) =
+            @inline $fname(val::UInt32, src::UInt32, width::UInt32=$ws) =
                 ccall($"$intrinsic", llvmcall, UInt32,
                       (UInt32, UInt32, UInt32),
-                      val, unsafe_trunc(UInt32, src), unsafe_trunc(UInt32, $pack_expr))
+                      val, src, pack(width, $mask))
+
+            # FIXME: replace this with a checked conversion once we have exceptions
+            @inline $fname(val::UInt32, src::Integer, width::Integer=$ws) =
+                $fname(val, unsafe_trunc(UInt32, src), unsafe_trunc(UInt32, width))
         end
     end
 end

--- a/src/pointer.jl
+++ b/src/pointer.jl
@@ -182,7 +182,7 @@ const CachedLoadPointers = Union{Tuple(DevicePtr{T,AS.Global}
     eltyp = convert(LLVMType, T)
 
     T_int = convert(LLVMType, Int)
-    T_int32 = LLVM.IntType(32, jlctx[])
+    T_int32 = LLVM.Int32Type(jlctx[])
     T_ptr = convert(LLVMType, Ptr{T})
 
     T_actual_ptr = LLVM.PointerType(eltyp)

--- a/test/device/intrinsics.jl
+++ b/test/device/intrinsics.jl
@@ -311,7 +311,7 @@ n = 14
 @eval function kernel_shuffle_down(d::CuDeviceArray{T}, n) where {T}
     t = threadIdx().x
     if t <= n
-        d[t] += shfl_down(d[t], unsafe_trunc(UInt32, n÷2))
+        d[t] += shfl_down(d[t], n÷2)
     end
 end
 @testset "down" for T in [Int32, Int64, Float32, Float64, AddableTuple]

--- a/test/device/intrinsics.jl
+++ b/test/device/intrinsics.jl
@@ -51,10 +51,18 @@ end
     _, out = @grab_output @on_device @cuprintf("Testing...\n")
     @test out == "Testing...$endline"
 
+    # narrow integer
+    _, out = @grab_output @on_device @cuprintf("Testing %d...\n", Int32(42))
+    @test out == "Testing 42...$endline"
+
+    # wide integer
     _, out = @grab_output @on_device @cuprintf("Testing %ld...\n", Int64(42))
     @test out == "Testing 42...$endline"
 
-    _, out = @grab_output @on_device @cuprintf("Testing %u %u...\n", blockIdx().x, threadIdx().x)
+    integer = Int == Int32 ? "%d" : "%ld"
+
+    _, out = @grab_output @on_device @cuprintf($"Testing $integer $integer...\n",
+                                               blockIdx().x, threadIdx().x)
     @test out == "Testing 1 1...$endline"
 
     _, out = @grab_output @on_device begin


### PR DESCRIPTION
Trial balloon, use Int instead of (U)Int32. We had been careful in order to preserve 32-bit precision of intrinsics, but sadly Julia is pretty bad at this and even trivial arithmetic immediately promotes to Int64.

Using Int simplifies stuff. As an additional advantage, the signedness and wider range of Int apparently allows for some better optimization by LLVM, but I'm not sure how that compares to the increased register pressure and eager `zext`s.

There's a kink though, because shuffle intrinsics require Int32 inputs, causing a inexactness check. Not sure how to deal with this.