### PR TITLE
Improve error reporting

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -54,6 +54,9 @@ Changes
     anymore. Although this might require more registers, it allows LLVM to
     simplify code ([#182]).
 
+  * Better error messages, showing backtraces into GPU code (#189) and detecting
+    common pitfalls like recursion or use of Base intrinsics (#210).
+
 
 Deprecations
 ------------

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -178,16 +178,22 @@ function irgen(ctx::CompilerContext)
         @assert last(method_stack) == method
         pop!(method_stack)
     end
-    params = Base.CodegenParams(cached=false,
-                                track_allocations=false,
-                                code_coverage=false,
-                                static_alloc=false,
-                                prefer_specsig=true,
-                                module_setup=hook_module_setup,
-                                module_activation=hook_module_activation,
-                                raise_exception=hook_raise_exception,
-                                emit_function=hook_emit_function,
-                                emitted_function=hook_emitted_function)
+    params = let
+        kwargs = Dict(
+                :cached             => false,
+                :track_allocations  => false,
+                :code_coverage      => false,
+                :static_alloc       => false,
+                :prefer_specsig     => true,
+                :module_setup       => hook_module_setup,
+                :module_activation  => hook_module_activation,
+                :raise_exception    => hook_raise_exception)
+        if VERSION >= v"0.7.0-beta.48"
+            kwargs[:emit_function]    = hook_emit_function
+            kwargs[:emitted_function] = hook_emitted_function
+        end
+        Base.CodegenParams(;kwargs...)
+    end
 
     # get the code
     mod = let

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -151,7 +151,7 @@ function irgen(ctx::CompilerContext)
 
         # check for recursion
         if method_instance in method_stack[1:end-1]
-            throw(CompilerError(ctx, "recursion is not supported", backtrace(ctx, method_stack)))
+            throw(CompilerError(ctx, "recursion is currently not supported", backtrace(ctx, method_stack)))
         end
 
         # check for Base methods that exist in CUDAnative too

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -617,8 +617,9 @@ function compile_function(ctx::CompilerContext)
         end
     end
 
-    # validate generated IR
+    # check generated IR
     validate_ir(ctx, mod)
+    verify(mod)
 
 
     ## machine code generation (PTX assembly)

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -679,7 +679,7 @@ function cufunction(dev::CuDevice, @nospecialize(f), @nospecialize(tt); kwargs..
     return cuda_fun, cuda_mod
 end
 
-function init_jit()
+function __init_compiler__()
     # enable generation of FMA instructions to mimic behavior of nvcc
     LLVM.clopts("--nvptx-fma-level=1")
 end

--- a/src/init.jl
+++ b/src/init.jl
@@ -99,5 +99,5 @@ function __init__()
     end
 
     CUDAdrv.apicall_hook[] = maybe_initialize
-    init_jit()
+    __init_compiler__()
 end

--- a/src/validation.jl
+++ b/src/validation.jl
@@ -4,15 +4,15 @@
 function validate_invocation(@nospecialize(ctx::CompilerContext))
     # get the method
     ms = Base.methods(ctx.f, ctx.tt)
-    isempty(ms)   && compiler_error(ctx, "no method found")
-    length(ms)!=1 && compiler_error(ctx, "no unique matching method")
+    isempty(ms)   && throw(CompilerError(ctx, "no method found"))
+    length(ms)!=1 && throw(CompilerError(ctx, "no unique matching method"))
     m = first(ms)
 
     # kernels can't return values
     if ctx.kernel
         rt = Base.return_types(ctx.f, ctx.tt)[1]
         if rt != Nothing
-            compiler_error(ctx, "kernel returning a value"; return_type=rt)
+            throw(CompilerError(ctx, "kernel returns a value of type $rt"))
         end
     end
 end
@@ -20,25 +20,24 @@ end
 
 ## IR validation
 
+const IRError = Tuple{String, StackTraces.StackTrace, Any} # kind, bt, meta
+
+struct InvalidIRError <: AbstractCompilerError
+    ctx::CompilerContext
+    errors::Vector{IRError}
+end
+
 const RUNTIME_FUNCTION = "call to the Julia runtime"
 const UNKNOWN_FUNCTION = "call to an unknown function"
 
-struct UnsupportedIRError <: Exception
-    kind::String
-    compiletrace::StackTraces.StackTrace
-    meta::Any
-end
-
-UnsupportedIRError(kind) = UnsupportedIRError(kind, nothing)
-
-# implement comparison, eg. for `unique(UnsupportedIRError[])`
-Base.:(==)(x::UnsupportedIRError, y::UnsupportedIRError) =
-    x.kind == y.kind && x.compiletrace == y.compiletrace && x.meta == y.meta
-
-function Base.showerror(io::IO, err::UnsupportedIRError)
-    print(io, "unsupported $(err.kind)")
-    if err.kind == RUNTIME_FUNCTION || err.kind == UNKNOWN_FUNCTION
-        print(io, " (", LLVM.name(err.meta), ")")
+function Base.showerror(io::IO, err::InvalidIRError)
+    println(io, "InvalidIRError: compiling $(signature(err.ctx)) resulted in invalid LLVM IR")
+    for (kind, bt, meta) in err.errors
+        print(io, "Reason: unsupported $kind")
+        if kind == RUNTIME_FUNCTION || kind == UNKNOWN_FUNCTION
+            print(io, " (", LLVM.name(meta), ")")
+        end
+        show_compiletrace(io, bt)
     end
 end
 
@@ -57,21 +56,17 @@ function backtrace(inst)
         depth += 1
     end
 
-    if !isempty(stack) && last(stack).func == :KernelWrapper
-        pop!(stack)
-    end
-
     stack
 end
 
-function validate_ir!(errors::Vector{>:UnsupportedIRError}, mod::LLVM.Module)
+function validate_ir!(errors::Vector{IRError}, mod::LLVM.Module)
     for f in functions(mod)
         validate_ir!(errors, f)
     end
     return errors
 end
 
-function validate_ir!(errors::Vector{>:UnsupportedIRError}, f::LLVM.Function)
+function validate_ir!(errors::Vector{IRError}, f::LLVM.Function)
     for bb in blocks(f), inst in instructions(bb)
         if isa(inst, LLVM.CallInst)
             validate_ir!(errors, inst)
@@ -83,25 +78,32 @@ end
 
 const special_fns = ["vprintf", "__nvvm_reflect"]
 
-function validate_ir!(errors::Vector{>:UnsupportedIRError}, inst::LLVM.CallInst)
+function validate_ir!(errors::Vector{IRError}, inst::LLVM.CallInst)
     dest_f = called_value(inst)
     dest_fn = LLVM.name(dest_f)
     lib = first(filter(lib->startswith(lib, "libjulia"), map(path->splitdir(path)[2], Libdl.dllist())))
     runtime = Libdl.dlopen(lib)
     if isa(dest_f, GlobalValue)
         if isdeclaration(dest_f) && intrinsic_id(dest_f) == 0 && !(dest_fn in special_fns)
-            compiletrace = backtrace(inst)
+            bt = backtrace(inst)
             if Libdl.dlsym_e(runtime, dest_fn) != C_NULL
-                push!(errors, UnsupportedIRError(RUNTIME_FUNCTION, compiletrace, dest_f))
+                push!(errors, (RUNTIME_FUNCTION, bt, dest_f))
             else
-                push!(errors, UnsupportedIRError(UNKNOWN_FUNCTION, compiletrace, dest_f))
+                push!(errors, (UNKNOWN_FUNCTION, bt, dest_f))
             end
         end
     elseif isa(dest_f, InlineAsm)
         # let's assume it's valid ASM
     end
 
-    return errors
+    errors
 end
 
-validate_ir(args...) = validate_ir!(Vector{UnsupportedIRError}(), args...)
+function validate_ir(ctx, args...)
+    errors = validate_ir!(IRError[], args...)
+
+    unique!(errors)
+    if !isempty(errors)
+        throw(InvalidIRError(ctx, errors))
+    end
+end

--- a/test/codegen.jl
+++ b/test/codegen.jl
@@ -159,7 +159,7 @@ end
 
     @test CUDAnative.code_ptx(devnull, ptx_valid_kernel, Tuple{}) == nothing
     @test CUDAnative.code_ptx(devnull, ptx_invalid_kernel, Tuple{}) == nothing
-    @test_throws CUDAnative.CompilerError CUDAnative.code_ptx(devnull, ptx_invalid_kernel, Tuple{}; kernel=true) == nothing
+    @test_throws CUDAnative.AbstractCompilerError CUDAnative.code_ptx(devnull, ptx_invalid_kernel, Tuple{}; kernel=true)
 end
 
 @testset "child functions" begin
@@ -204,53 +204,6 @@ end
         asm = sprint(io->CUDAnative.code_ptx(io, ptx_entry, Tuple{Int64};
                                              kernel=true, maxregs=42))
         @test occursin(".maxnreg 42", asm)
-    end
-end
-end
-
-@testset "IR validation" begin
-@testset "delayed lookup" begin
-    @eval codegen_ref_nonexisting() = nonexisting
-    try
-         CUDAnative.code_ptx(codegen_ref_nonexisting, Tuple{})
-    catch err
-        @test isa(err, CUDAnative.CompilerError)
-        msg = sprint(io->showerror(io, err))
-        @test occursin("could not compile codegen_ref_nonexisting() for GPU; unsupported LLVM IR", msg)
-        @test occursin("Reason: unsupported call to the Julia runtime", msg)
-        if VERSION >= v"0.7.0-alpha.37"
-            @test occursin(r"\[1\] codegen_ref_nonexisting at .*codegen.jl", msg)
-        end
-    end
-end
-
-@testset "generic call" begin
-    @eval codegen_call_nonexisting() = nonexisting()
-    try
-         CUDAnative.code_ptx(codegen_call_nonexisting, Tuple{})
-    catch err
-        @test isa(err, CUDAnative.CompilerError)
-        msg = sprint(io->showerror(io, err))
-        @test occursin("could not compile codegen_call_nonexisting() for GPU; unsupported LLVM IR", msg)
-        @test occursin("Reason: unsupported call to the Julia runtime", msg)
-        if VERSION >= v"0.7.0-alpha.37"
-            @test occursin(r"\[1\] codegen_call_nonexisting at .*codegen.jl", msg)
-        end
-    end
-end
-
-@testset "compile traces" begin
-    @eval codegen_call_inner() = error()
-    @eval codegen_call_outer() = codegen_call_inner()
-    try
-         CUDAnative.code_ptx(codegen_call_outer, Tuple{})
-    catch err
-        @test isa(err, CUDAnative.CompilerError)
-        msg = sprint(io->showerror(io, err))
-        if VERSION >= v"0.7.0-alpha.37"
-            @test occursin(r"\[1\] codegen_call_inner at .*codegen.jl", msg)
-            @test occursin(r"\[2\] codegen_call_outer at .*codegen.jl", msg)
-        end
     end
 end
 end
@@ -366,6 +319,47 @@ end
 
     test_name(codegen_closure, "ptxcall_anonymous"; kernel=true)
     test_name(codegen_closure, "ptxcall_codegen_renamed"; kernel=true, alias="codegen_renamed")
+end
+
+end
+
+
+############################################################################################
+
+
+@testset "errors" begin
+
+# validation happens in compile_function, which is called by code_ptx
+
+@testset "recursion" begin
+    @eval @noinline error_recurse_outer(i) = i > 0 ? i : error_recurse_inner(i)
+    @eval @noinline error_recurse_inner(i) = i < 0 ? i : error_recurse_outer(i)
+
+    @test_throws_message(CUDAnative.CompilerError, CUDAnative.code_ptx(error_recurse_outer, Tuple{Int})) do msg
+        occursin("recursion is not supported", msg) &&
+        occursin("[1] error_recurse_outer", msg) &&
+        occursin("[2] error_recurse_inner", msg) &&
+        occursin("[3] error_recurse_outer", msg)
+    end
+end
+
+@testset "non-isbits arguments" begin
+    @eval error_use_nonbits(i) = sink(unsafe_trunc(Int,i))
+
+    @test_throws_message(CUDAnative.CompilerError, CUDAnative.code_ptx(error_use_nonbits, Tuple{BigInt})) do msg
+        occursin("passing and using non-bitstype argument", msg) &&
+        occursin("BigInt", msg)
+    end
+end
+
+@testset "invalid LLVM IR" begin
+    @eval @noinline error_invalid_ir(i) = println(i)
+
+    @test_throws_message(CUDAnative.InvalidIRError, CUDAnative.code_ptx(error_invalid_ir, Tuple{Int})) do msg
+        occursin("invalid LLVM IR", msg) &&
+        occursin("[1] println", msg) &&
+        occursin("[2] error_invalid_ir", msg)
+    end
 end
 
 end

--- a/test/codegen.jl
+++ b/test/codegen.jl
@@ -337,7 +337,7 @@ if VERSION >= v"0.7.0-beta.48"
     @eval @noinline error_recurse_inner(i) = i < 0 ? i : error_recurse_outer(i)
 
     @test_throws_message(CUDAnative.CompilerError, CUDAnative.code_llvm(error_recurse_outer, Tuple{Int})) do msg
-        occursin("recursion is not supported", msg) &&
+        occursin("recursion is currently not supported", msg) &&
         occursin("[1] error_recurse_outer", msg) &&
         occursin("[2] error_recurse_inner", msg) &&
         occursin("[3] error_recurse_outer", msg)

--- a/test/codegen.jl
+++ b/test/codegen.jl
@@ -331,6 +331,7 @@ end
 
 # some validation happens in the emit_function hook, which is called by code_llvm
 
+if VERSION >= v"0.7.0-beta.48"
 @testset "recursion" begin
     @eval @noinline error_recurse_outer(i) = i > 0 ? i : error_recurse_inner(i)
     @eval @noinline error_recurse_inner(i) = i < 0 ? i : error_recurse_outer(i)
@@ -342,11 +343,14 @@ end
         occursin("[3] error_recurse_outer", msg)
     end
 end
+end
 
+if VERSION >= v"0.7.0-beta.48"
 @testset "base intrinsics" begin
     @eval @noinline error_base_intrinsics(i) = sin(i)
 
     @test_logs (:warn, "calls to Base intrinsics might be GPU incompatible") CUDAnative.code_llvm(devnull, error_base_intrinsics, Tuple{Int})
+end
 end
 
 # some validation happens in compile_function, which is called by code_ptx

--- a/test/device/execution.jl
+++ b/test/device/execution.jl
@@ -271,9 +271,6 @@ end
 
     @eval exec_pass_nonbits_specialized(T, i) = sink(unsafe_trunc(T,i))
     @cuda exec_pass_nonbits_specialized(Int, 1.)
-
-    @eval exec_pass_nonbits_used(i) = sink(unsafe_trunc(Int,i))
-    @test_throws CUDAnative.CompilerError @cuda exec_pass_nonbits_used(big"1")
 end
 
 

--- a/test/util.jl
+++ b/test/util.jl
@@ -1,6 +1,25 @@
 # NOTE: all kernel function definitions are prefixed with @eval to force toplevel definition,
 #       avoiding boxing as seen in https://github.com/JuliaLang/julia/issues/18077#issuecomment-255215304
 
+# @test_throw, with additional testing for the exception message
+macro test_throws_message(f, typ, ex...)
+    quote
+        msg = ""
+        @test_throws $(esc(typ)) try
+            $(esc(ex...))
+        catch err
+            msg = sprint(showerror, err)
+            rethrow()
+        end
+
+        if !$(esc(f))(msg)
+            # @test should return its result, but doesn't
+            @error "Failed to validate error message\n$msg"
+        end
+        @test $(esc(f))(msg)
+    end
+end
+
 # NOTE: based on test/pkg.jl::capture_stdout, but doesn't discard exceptions
 macro grab_output(ex)
     quote


### PR DESCRIPTION
Detect calls of base intrinsics (#27):

```
julia> foo(i) = sin(i)
foo (generic function with 1 method)

julia> @cuda foo(1)
┌ Warning: calls to Base intrinsics might be GPU incompatible
│   exception =
│    You called sin(x::T) where T<:Union{Float32, Float64} in Base.Math at special/trig.jl:30, maybe you intended to call sin(x::Float64) in CUDAnative at /home/tbesard/Julia/CUDAnative/src/device/libdevice.jl:12 instead?
│    Stacktrace:
│     [1] sin at special/trig.jl:30
│     [2] foo at REPL[6]:1
└ @ CUDAnative compiler.jl:172
```

Detect recursive codegen (#122):

```
julia> @noinline foo(i) = i<0 ? i : bar(i)
foo (generic function with 1 method)

julia> @noinline bar(i) = i<0 ? i : foo(i)
bar (generic function with 1 method)

julia> @cuda foo(1)
ERROR: GPU compilation failed, try inspecting generated code with any of the @device_code_... macros
CompilerError: could not compile foo(Int64); recursion is not supported
Stacktrace:
 [1] foo at REPL[3]:1
 [2] bar at REPL[4]:1
 [3] foo at REPL[3]:1 (repeats 2 times)
Stacktrace:
 [1] (::getfield(CUDAnative, Symbol("#hook_emit_function#52")){CUDAnative.CompilerContext})(::Core.MethodInstance, ::Core.CodeInfo, ::Any) at /home/tbesard/Julia/CUDAnative/src/compiler.jl:154
 [2] irgen(::CUDAnative.CompilerContext) at /home/tbesard/Julia/CUDAnative/src/compiler.jl:194
 [3] compile_function(::CUDAnative.CompilerContext) at /home/tbesard/Julia/CUDAnative/src/compiler.jl:584
 [4] #cufunction#83(::Base.Iterators.Pairs{Symbol,typeof(foo),Tuple{Symbol},NamedTuple{(:inner_f,),Tuple{typeof(foo)}}}, ::Function, ::CUDAdrv.CuDevice, ::Function, ::Type) at /home/tbesard/Julia/CUDAnative/src/compiler.jl:657
 [5] (::getfield(CUDAnative, Symbol("#kw##cufunction")))(::Any, ::typeof(cufunction), ::CUDAdrv.CuDevice, ::Function, ::Type) at ./none:0
 [6] _cuda(::CUDAnative.KernelWrapper{typeof(foo)}, ::typeof(foo), ::Tuple{}, ::Tuple{}, ::Int64) at /home/tbesard/Julia/CUDAnative/src/execution.jl:235
 [7] top-level scope at gcutils.jl:87
```

Depends on https://github.com/JuliaLang/julia/pull/27791

Fix #205