### PR TITLE
Improve capability handling.

### DIFF
--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -643,14 +643,7 @@ function cufunction(dev::CuDevice, @nospecialize(f), @nospecialize(tt); kwargs..
     CUDAnative.configured || error("CUDAnative.jl has not been configured; cannot JIT code.")
     @assert isa(f, Core.Function)
 
-    # select a capability level
-    dev_cap = capability(dev)
-    compat_caps = filter(cap -> cap <= dev_cap, target_support)
-    isempty(compat_caps) &&
-        error("Device capability v$dev_cap not supported by available toolchain")
-    cap = maximum(compat_caps)
-
-    ctx = CompilerContext(f, tt, cap, true; kwargs...)
+    ctx = CompilerContext(f, tt, supported_capability(dev), true; kwargs...)
 
     if compile_hook[] != nothing
         global globalUnique

--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -2,21 +2,6 @@
 
 using InteractiveUtils
 
-# Return the capability of the current context's device, or a sane fall-back.
-function current_capability()
-    fallback = minimum(target_support)
-    if !initialized[]
-        return fallback
-    end
-
-    ctx = CuCurrentContext()
-    if ctx == nothing
-        return fallback
-    end
-
-    return capability(device(ctx))
-end
-
 
 #
 # code_* replacements

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -33,3 +33,28 @@ for level in [:trace, :debug, :info, :warn, :error, :fatal]
         end
     end
 end
+
+
+# device capability handling
+
+# select the highest capability that is supported by both the toolchain and device
+function supported_capability(dev::CuDevice)
+    dev_cap = capability(dev)
+    compat_caps = filter(cap -> cap <= dev_cap, target_support)
+    isempty(compat_caps) &&
+        error("Device capability v$dev_cap not supported by available toolchain")
+
+    return maximum(compat_caps)
+end
+
+# return the capability of the current context's device, or a sane fall-back
+function current_capability()
+    ctx = CuCurrentContext()
+    if ctx == nothing
+        # newer devices tend to support cleaner code (higher-level instructions, etc)
+        # so target the most recent device as supported by this toolchain
+        return maximum(target_support)
+    end
+
+    return supported_capability(device(ctx))
+end


### PR DESCRIPTION
Don't perform reflection with the raw device capability (fix #194),
remove the redundant initialization checks, and as a fallback return
the most recent capability as supported by the toolchain.