### PR TITLE
Strip RefValue when invoking kernels.

### DIFF
--- a/src/execution.jl
+++ b/src/execution.jl
@@ -20,6 +20,7 @@ cudaconvert(x::Tuple) = cudaconvert.(x)
 @generated function cudaconvert(x::NamedTuple)
     Expr(:tuple, (:($f=cudaconvert(x.$f)) for f in fieldnames(x))...)
 end
+cudaconvert(x::Base.RefValue) = cudaconvert(x[])
 
 # fast lookup of global world age
 world_age() = ccall(:jl_get_tls_world_age, UInt, ())


### PR DESCRIPTION
Doesn't make much sense across the CPU/GPU barrier anyway,
and makes it possible to broadcast eg. RefValue{::CuArray}
(which isn't bits, both ::CuArray and ::RefValue).

Demo:

```julia
using CuArrays, CUDAnative

foobar(idx, A) = A[idx]
foobar.(CuArray([1]), Base.RefValue(CuArray([42])))
```
