### PR TITLE
Strip invariant.load from input pointers.

### DIFF
--- a/test/device/codegen.jl
+++ b/test/device/codegen.jl
@@ -2,6 +2,23 @@
 
 ############################################################################################
 
+@testset "LLVM" begin
+
+@testset "invariant tuple passing" begin
+    @eval function kernel(ptr, x)
+        i = CUDAnative.threadIdx_x()
+        @inbounds unsafe_store!(ptr, x[i], 1)
+    end
+
+    buf = Mem.alloc(Float64)
+    @cuda kernel(convert(Ptr{Float64}, buf.ptr), (1., 2., ))
+    @test Mem.download(Float64, buf) == [1.]
+end
+
+end
+
+############################################################################################
+
 @testset "SASS" begin
 
 @testset "basic reflection" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,20 @@
+# Pkg.test runs with --check_bounds=1, forcing all bounds checks.
+# This is incompatible with CUDAnative (see JuliaGPU/CUDAnative.jl#98)
+if Base.JLOptions().check_bounds == 1
+    @warn "Running with --check-bounds=yes, restarting tests."
+    file = @__FILE__
+    run(```
+        $(Base.julia_cmd())
+            --code-coverage=$(("none", "user", "all")[Base.JLOptions().code_coverage + 1])
+            --color=$(Base.have_color ? "yes" : "no")
+            --compiled-modules=$(Bool(Base.JLOptions().use_compiled_modules) ? "yes" : "no")
+            --startup-file=$(Base.JLOptions().startupfile == 1 ? "yes" : "no")
+            --track-allocation=$(("none", "user", "all")[Base.JLOptions().malloc_log + 1])
+            $file
+      ```)
+    exit()
+end
+
 using CUDAnative, CUDAdrv
 import LLVM
 


### PR DESCRIPTION
We violate its assumption when rewriting the kernel entrypoint.