### PR TITLE
Don't inline if we don't need to.

### DIFF
--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -35,9 +35,6 @@ end
 function code_llvm(io::IO, ctx::CompilerContext; optimize::Bool=true,
                    dump_module::Bool=false, strip_ir_metadata::Bool=true)
     mod, entry = irgen(ctx)
-    if ctx.kernel
-        entry = promote_kernel!(ctx, mod, entry)
-    end
     if optimize
         optimize!(ctx, mod, entry)
     end

--- a/src/validation.jl
+++ b/src/validation.jl
@@ -59,25 +59,47 @@ function Base.showerror(io::IO, err::InvalidIRError)
 end
 
 # generate a pseudo-backtrace from LLVM IR instruction debug information
-function backtrace(inst)
+function backtrace(inst, bt = StackTraces.StackFrame[])
     name = Ref{Cstring}()
     filename = Ref{Cstring}()
     line = Ref{Cuint}()
     col = Ref{Cuint}()
 
+    # look up the debug information from the current instruction
     depth = 0
-    bt = StackTraces.StackFrame[]
-    VERSION >= v"0.7.0-alpha.37" || return bt
     while LLVM.API.LLVMGetSourceLocation(LLVM.ref(inst), depth, name, filename, line, col) == 1
         frame = StackTraces.StackFrame(replace(unsafe_string(name[]), r";$"=>""), unsafe_string(filename[]), line[])
         push!(bt, frame)
         depth += 1
     end
 
-    # wrapping the kernel _does_ trigger a new debug info frame,
-    # so just get rid of the wrapper frame.
-    if !isempty(bt) && last(bt).func == :KernelWrapper
-        pop!(bt)
+    # move up the call chain
+    f = LLVM.parent(LLVM.parent(inst))
+    callers = uses(f)
+    if isempty(callers)
+        # wrapping the kernel _does_ trigger a new debug info frame,
+        # so just get rid of the wrapper frame.
+        if !isempty(bt) && last(bt).func == :KernelWrapper
+            pop!(bt)
+        end
+    else
+        # figure out the call sites of this instruction
+        call_sites = unique(callers) do call
+            # there could be multiple calls, originating from the same source location
+            md = metadata(user(call))
+            if haskey(md, LLVM.MD_dbg)
+                md[LLVM.MD_dbg]
+            else
+                nothing
+            end
+        end
+
+        if length(call_sites) > 1
+            frame = StackTraces.StackFrame("multiple call sites", "unknown", 0)
+            push!(bt, frame)
+        elseif length(call_sites) == 1
+            backtrace(user(first(call_sites)), bt)
+        end
     end
 
     bt

--- a/test/codegen.jl
+++ b/test/codegen.jl
@@ -49,7 +49,7 @@ end
     @eval codegen_parent(i) = codegen_child(i)
 
     ir = sprint(io->CUDAnative.code_llvm(io, codegen_parent, Tuple{Int}))
-    @test_broken occursin(r"call .+ @julia_codegen_child_", ir)
+    @test occursin(r"call .+ @julia_codegen_child_", ir)
 end
 
 @testset "JuliaLang/julia#21121" begin


### PR DESCRIPTION
Hurts performance a little, but keeps us from violating the semantics of Julia's non-IPO safe metadata.