### PR TITLE
Handle exceptions from throw_...

### DIFF
--- a/examples/pairwise.jl
+++ b/examples/pairwise.jl
@@ -101,12 +101,14 @@ function pairwise_dist_gpu(lat::Vector{Float32}, lon::Vector{Float32})
     return Array(rowresult_gpu)
 end
 
-
-# generate reasonable data
-const n = 10000
-const lat = rand(Float32, n) .* 45
-const lon = rand(Float32, n) .* -120
-
 using Test
 
-@test pairwise_dist_cpu(lat, lon) ≈ pairwise_dist_gpu(lat, lon)
+# generate reasonable data
+function main(n = 10000)
+    lat = rand(Float32, n) .* 45
+    lon = rand(Float32, n) .* -120
+
+
+    @test pairwise_dist_cpu(lat, lon) ≈ pairwise_dist_gpu(lat, lon)
+end
+main()

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -89,8 +89,6 @@ function raise_exception(insblock::BasicBlock, ex::Value)
 
         cuprintf!(builder, "ERROR: an unknown exception occurred$cuprintf_endline")
         call!(builder, trap)
-
-        ret!(builder)
     end
 end
 

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -306,6 +306,7 @@ function irgen(ctx::CompilerContext)
         add!(pm, ModulePass("ThrowRemoval", remove_throw!))
         add!(pm, FunctionPass("ControlFlowFixup", fixup_controlflow!))
         always_inliner!(pm)
+        verifier!(pm)
         run!(pm, mod)
     end
 

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -304,7 +304,7 @@ function irgen(ctx::CompilerContext)
     # minimal optimization to get rid of useless generated code (llvmcall, kernel wrapper)
     ModulePassManager() do pm
         add!(pm, ModulePass("ThrowRemoval", remove_throw!))
-        add!(pm, BasicBlockPass("ControlFlowFixup", fixup_controlflow!))
+        add!(pm, FunctionPass("ControlFlowFixup", fixup_controlflow!))
         always_inliner!(pm)
         verifier!(pm)
         run!(pm, mod)
@@ -386,85 +386,95 @@ end
 # HACK: this pass removes control flow that confuses `ptxas`
 #
 # TODO: do this with structured CFG with LLVM?
-function fixup_controlflow!(bb::LLVM.BasicBlock)
-    f = LLVM.parent(bb)
-    ctx = LLVM.context(bb)
+function fixup_controlflow!(f::LLVM.Function)
+    ctx = LLVM.context(f)
 
     exit_ft = LLVM.FunctionType(LLVM.VoidType(ctx))
     exit = InlineAsm(exit_ft, "exit;", "", true)
 
     changed = false
 
-    # remove calls to `trap`
-    for inst in instructions(bb)
-        if isa(inst, LLVM.CallInst) && LLVM.name(called_value(inst)) == "llvm.trap"
-            # replace with call to `exit`
-            # FIXME: this still confuses `ptxas`
-            #let builder = Builder(ctx)
-            #    position!(builder, inst)
-            #    call!(builder, exit)
-            #    dispose(builder)
-            #end
+    # remove `noreturn` attributes
+    attrs = function_attributes(f)
+    delete!(attrs, EnumAttribute("noreturn", 0, ctx))
 
-            unsafe_delete!(bb, inst)
-            changed = true
+    for bb in blocks(f)
+        # remove calls to `trap`
+        for inst in instructions(bb)
+            if isa(inst, LLVM.CallInst) && LLVM.name(called_value(inst)) == "llvm.trap"
+                # replace with call to `exit`
+                # FIXME: this still confuses `ptxas`, `brkpt` seems to work but that's fragile
+                #let builder = Builder(ctx)
+                #    position!(builder, inst)
+                #    call!(builder, exit)
+                #    dispose(builder)
+                #end
+
+                unsafe_delete!(bb, inst)
+                changed = true
+            end
         end
-    end
 
-    # remove `unreachable `terminators
-    unreachable = terminator(bb)
-    if isa(unreachable, LLVM.UnreachableInst)
-        unsafe_delete!(bb, unreachable)
-        changed = true
+        # remove `unreachable `terminators
+        unreachable = terminator(bb)
+        if isa(unreachable, LLVM.UnreachableInst)
+            unsafe_delete!(bb, unreachable)
+            changed = true
 
-        try
-            terminator(bb)
-            # the basic-block is still terminated properly, nothing to do
-            # (this can happen with `ret; unreachable`)
-            # TODO: `unreachable; unreachable`
-        catch ex
-            isa(ex, UndefRefError) || rethrow(ex)
+            try
+                terminator(bb)
+                # the basic-block is still terminated properly, nothing to do
+                # (this can happen with `ret; unreachable`)
+                # TODO: `unreachable; unreachable`
+            catch ex
+                isa(ex, UndefRefError) || rethrow(ex)
 
-            let builder = Builder(ctx)
-                position!(builder, bb)
+                let builder = Builder(ctx)
+                    position!(builder, bb)
 
-                # find the predecessors to this block
-                predecessors = LLVM.BasicBlock[]
-                for bb′ in blocks(f), inst in instructions(bb′)
-                    if isa(inst, LLVM.BrInst)
-                        if bb in successors(inst)
-                            push!(predecessors, bb′)
-                        end
-                    end
-                end
-
-                # find the fall through successors
-                if length(predecessors) == 1
-                    predecessor = first(predecessors)
-                    br = terminator(predecessor)
-
-                    # find the other successors
-                    targets = successors(br)
-                    if length(targets) == 2
-                        for target in targets
-                            if target != bb
-                                br!(builder, target)
-                                break
+                    # find the predecessors to this block
+                    predecessors = LLVM.BasicBlock[]
+                    for bb′ in blocks(f), inst in instructions(bb′)
+                        if isa(inst, LLVM.BrInst)
+                            if bb in successors(inst)
+                                push!(predecessors, bb′)
                             end
                         end
-                    else
-                        @warn "unreachable control flow with $(length(targets))-way branching predecessor"
-                        unreachable!(builder)
                     end
-                elseif length(predecessors) > 1
-                    @warn "unreachable control flow with multiple predecessors"
-                    unreachable!(builder)
-                else
-                    # this block has no predecessors, and will get optimized away
-                    unreachable!(builder)
-                end
 
-                dispose(builder)
+                    # find the fall through successors
+                    if length(predecessors) == 1
+                        predecessor = first(predecessors)
+                        br = terminator(predecessor)
+
+                        # find the other successors
+                        targets = successors(br)
+                        if length(targets) == 2
+                            for target in targets
+                                if target != bb
+                                    br!(builder, target)
+                                    break
+                                end
+                            end
+                        else
+                            @warn "unreachable control flow with $(length(targets))-way branching predecessor"
+                            unreachable!(builder)
+                        end
+                    elseif length(predecessors) > 1
+                        @warn "unreachable control flow with multiple predecessors"
+                        unreachable!(builder)
+                    else
+                        # this block has no predecessors, so we can't fall through
+                        ft = eltype(llvmtype(f))
+                        if return_type(ft) == LLVM.VoidType(ctx)
+                            ret!(builder)
+                        else
+                            unreachable!(builder)
+                        end
+                    end
+
+                    dispose(builder)
+                end
             end
         end
     end

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -424,11 +424,14 @@ function fixup_controlflow!(f::LLVM.Function)
                         br = terminator(predecessor)
 
                         # find the other successors
-                        targets = collect(successors(br))
-                        filter!(target -> target != bb, targets)
-                        if length(targets) == 1
-                            fallthrough = first(targets)
-                            br!(builder, fallthrough)
+                        targets = successors(br)
+                        if length(targets) == 2
+                            for target in targets
+                                if target != bb
+                                    br!(builder, target)
+                                    break
+                                end
+                            end
                         else
                             @warn "unreachable control flow with $(length(targets))-way branching predecessor"
                             unreachable!(builder)

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -603,6 +603,7 @@ function optimize!(ctx::CompilerContext, mod::LLVM.Module, entry::LLVM.Function)
     let pm = ModulePassManager()
         add_library_info!(pm, triple(mod))
         add_transform_info!(pm, tm)
+        internalize!(pm, [LLVM.name(entry)])
         ccall(:jl_add_optimization_passes, Cvoid,
               (LLVM.API.LLVMPassManagerRef, Cint),
               LLVM.ref(pm), Base.JLOptions().opt_level)

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -313,7 +313,7 @@ function irgen(ctx::CompilerContext)
     return mod, entry
 end
 
-# HACK: this pass replaces `julia_throw_*` functions with a simple print & trap
+# HACK: this pass replaces `julia_throw_*` void functions with a simple print & trap
 #
 # this is necessary even though we already have a `raise_exception` hook that just prints,
 # as many `throw_...` functions are now `@noinline` which means their arguments survive and
@@ -432,9 +432,7 @@ function fixup_controlflow!(bb::LLVM.BasicBlock)
                 predecessors = LLVM.BasicBlock[]
                 for bb′ in blocks(f), inst in instructions(bb′)
                     if isa(inst, LLVM.BrInst)
-                        targets = filter(x->llvmtype(x) == LLVM.LabelType(ctx),
-                                         operands(inst))
-                        if bb in targets
+                        if bb in successors(inst)
                             push!(predecessors, bb′)
                         end
                     end

--- a/src/device/array.jl
+++ b/src/device/array.jl
@@ -108,15 +108,6 @@ end
 
 Base.IndexStyle(::Type{<:CuDeviceArray}) = Base.IndexLinear()
 
-# bounds checking is currently broken due to a PTX assembler issue (see #4)
-Base.checkbounds(::CuDeviceArray, I...) = nothing
-
-# replace boundserror-with-arguments to a non-allocating, argumentless version
-# TODO: can this be fixed by stack-allocating immutables with heap references?
-struct CuBoundsError <: Exception end
-@inline Base.throw_boundserror(A::CuDeviceArray, I) =
-    (Base.@_noinline_meta; throw(CuBoundsError()))
-
 
 ## other
 

--- a/src/device/intrinsics/output.jl
+++ b/src/device/intrinsics/output.jl
@@ -2,6 +2,8 @@
 
 export @cuprintf
 
+const cuprintf_endline = Sys.iswindows() ? "\r\n" : "\n"
+
 @generated function promote_c_argument(arg)
     # > When a function with a variable-length argument list is called, the variable
     # > arguments are passed using C's old ``default argument promotions.'' These say that

--- a/test/codegen.jl
+++ b/test/codegen.jl
@@ -25,8 +25,8 @@ end
     @eval codegen_exception() = throw(DivideError())
     ir = sprint(io->CUDAnative.code_llvm(io, codegen_exception, Tuple{}))
 
-    # exceptions should get lowered to a plain trap...
-    @test occursin("llvm.trap", ir)
+    # plain exceptions should get lowered to cuprintf (see `raise_exception`)
+    @test occursin("vprintf", ir)
     # not a jl_throw referencing a jl_value_t representing the exception
     @test !occursin("jl_value_t", ir)
     @test !occursin("jl_throw", ir)

--- a/test/codegen.jl
+++ b/test/codegen.jl
@@ -205,7 +205,7 @@ end
     end
 
     asm = sprint(io->CUDAnative.code_ptx(io, ptx_parent, Tuple{Int64}))
-    @test_broken occursin(r"call.uni\s+julia_ptx_child_"m, asm)
+    @test occursin(r"call.uni\s+julia_ptx_child_"m, asm)
 end
 
 @testset "kernel functions" begin
@@ -215,7 +215,7 @@ end
     asm = sprint(io->CUDAnative.code_ptx(io, ptx_entry, Tuple{Int64}; kernel=true))
     @test occursin(r"\.visible \.entry ptxcall_ptx_entry_", asm)
     @test !occursin(r"\.visible \.func julia_ptx_nonentry_", asm)
-    @test_broken occursin(r"\.func julia_ptx_nonentry_", asm)
+    @test occursin(r"\.func julia_ptx_nonentry_", asm)
 
 @testset "property_annotations" begin
     asm = sprint(io->CUDAnative.code_ptx(io, ptx_entry, Tuple{Int64}; kernel=true))
@@ -260,7 +260,7 @@ end
     end
 
     asm = sprint(io->CUDAnative.code_ptx(io, codegen_child_reuse_parent1, Tuple{Int}))
-    @test_broken occursin(r".func julia_codegen_child_reuse_child_", asm)
+    @test occursin(r".func julia_codegen_child_reuse_child_", asm)
 
     @eval function codegen_child_reuse_parent2(i)
         codegen_child_reuse_child(i+1)
@@ -268,7 +268,7 @@ end
     end
 
     asm = sprint(io->CUDAnative.code_ptx(io, codegen_child_reuse_parent2, Tuple{Int}))
-    @test_broken occursin(r".func julia_codegen_child_reuse_child_", asm)
+    @test occursin(r".func julia_codegen_child_reuse_child_", asm)
 end
 
 @testset "child function reuse bis" begin

--- a/test/device/array.jl
+++ b/test/device/array.jl
@@ -94,17 +94,17 @@ end
         return array[1]
     end
 
-    # NOTE: these tests verify that bounds checking is _disabled_ (see #4)
-
     ir = sprint(io->CUDAnative.code_llvm(io, array_oob_1d, (CuDeviceArray{Int,1,AS.Global},)))
-    @test !occursin("trap", ir)
+    @test occursin("trap", ir)
+    @test !occursin("throw_boundserror", ir)
 
     @eval function array_oob_2d(array)
         return array[1, 1]
     end
 
     ir = sprint(io->CUDAnative.code_llvm(io, array_oob_2d, (CuDeviceArray{Int,2,AS.Global},)))
-    @test !occursin("trap", ir)
+    @test occursin("trap", ir)
+    @test !occursin("throw_boundserror", ir)
 end
 
 @testset "views" begin

--- a/test/device/array.jl
+++ b/test/device/array.jl
@@ -96,7 +96,8 @@ end
 
     ir = sprint(io->CUDAnative.code_llvm(io, array_oob_1d, (CuDeviceArray{Int,1,AS.Global},)))
     @test occursin("trap", ir)
-    @test !occursin("throw_boundserror", ir)
+    @test !occursin("julia_throw_boundserror", ir)
+    @test occursin("ptx_throw_boundserror", ir)
 
     @eval function array_oob_2d(array)
         return array[1, 1]
@@ -104,7 +105,8 @@ end
 
     ir = sprint(io->CUDAnative.code_llvm(io, array_oob_2d, (CuDeviceArray{Int,2,AS.Global},)))
     @test occursin("trap", ir)
-    @test !occursin("throw_boundserror", ir)
+    @test !occursin("julia_throw_boundserror", ir)
+    @test occursin("ptx_throw_boundserror", ir)
 end
 
 @testset "views" begin

--- a/test/device/array.jl
+++ b/test/device/array.jl
@@ -95,7 +95,6 @@ end
     end
 
     ir = sprint(io->CUDAnative.code_llvm(io, array_oob_1d, (CuDeviceArray{Int,1,AS.Global},)))
-    @test occursin("trap", ir)
     @test !occursin("julia_throw_boundserror", ir)
     @test occursin("ptx_throw_boundserror", ir)
 
@@ -104,7 +103,6 @@ end
     end
 
     ir = sprint(io->CUDAnative.code_llvm(io, array_oob_2d, (CuDeviceArray{Int,2,AS.Global},)))
-    @test occursin("trap", ir)
     @test !occursin("julia_throw_boundserror", ir)
     @test occursin("ptx_throw_boundserror", ir)
 end


### PR DESCRIPTION
Apparently LLVM managed to optimize many `throw`s away, which breaks now that we don't inline everything anymore. Let's try to work around some.