### PR TITLE
Remove kernel wrapper

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 LLVM = "929cbde3-209d-540e-8aea-75f648917ca0"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [extras]

--- a/examples/blackscholes.jl
+++ b/examples/blackscholes.jl
@@ -81,6 +81,8 @@ function blackscholes_kernel(sptprice::AbstractArray{Float32},
         call = sptprice[i] * NofXd1 - c1
         out[i] = call - futureValue + sptprice[i]
     end
+
+    return
 end
 
 

--- a/examples/hello_world.jl
+++ b/examples/hello_world.jl
@@ -1,11 +1,15 @@
 using CUDAdrv, CUDAnative
 
 if Sys.iswindows()
-	hello_world() =
-   	@cuprintf("Greetings from block %lld, thread %lld!\n", Int64(blockIdx().x), Int64(threadIdx().x))
+    function hello_world()
+        @cuprintf("Greetings from block %lld, thread %lld!\n", Int64(blockIdx().x), Int64(threadIdx().x))
+        return
+    end
 else
-	hello_world() =
-    	@cuprintf("Greetings from block %ld, thread %ld!\n", Int64(blockIdx().x), Int64(threadIdx().x))
+    function hello_world()
+       @cuprintf("Greetings from block %ld, thread %ld!\n", Int64(blockIdx().x), Int64(threadIdx().x))
+       return
+   end
 end
 @cuda blocks=2 threads=2 hello_world()
 synchronize()

--- a/examples/multigpu.jl
+++ b/examples/multigpu.jl
@@ -5,6 +5,7 @@ using Test
 function vadd(gpu, a, b, c)
     i = threadIdx().x + blockDim().x * ((blockIdx().x-1) + (gpu-1) * gridDim().x)
     c[i] = a[i] + b[i]
+    return
 end
 
 gpus = Int(length(devices()))

--- a/examples/oob.jl
+++ b/examples/oob.jl
@@ -13,6 +13,7 @@ a = CuArray{Float32}(10)
 function memset(a, val)
     i = (blockIdx().x-1) * blockDim().x + threadIdx().x
     a[i] = val
+    return
 end
 
 @cuda threads=11 memset(a, 0f0)

--- a/examples/pairwise.jl
+++ b/examples/pairwise.jl
@@ -71,6 +71,8 @@ function pairwise_dist_kernel(lat::CuDeviceVector{Float32}, lon::CuDeviceVector{
 
         @inbounds rowresult[i, j] = haversine_gpu(lat_i, lon_i, lat_j, lon_j, 6372.8f0)
     end
+
+    return
 end
 
 function pairwise_dist_gpu(lat::Vector{Float32}, lon::Vector{Float32})

--- a/examples/peakflops.jl
+++ b/examples/peakflops.jl
@@ -16,6 +16,8 @@ function kernel_100fma(a, b, c, out)
     end
 
     @inbounds out[i] = CUDAnative.fma(a_val, b_val, c_val)
+
+    return
 end
 
 function peakflops(n::Integer=5000, dev::CuDevice=CuDevice(0))

--- a/examples/reduce/reduce.jl
+++ b/examples/reduce/reduce.jl
@@ -77,6 +77,8 @@ function reduce_grid(op::F, input::CuDeviceVector{T}, output::CuDeviceVector{T},
     if threadIdx().x == 1
         @inbounds output[blockIdx().x] = val
     end
+
+    return
 end
 
 """

--- a/examples/scan.jl
+++ b/examples/scan.jl
@@ -52,6 +52,8 @@ function gpu_accumulate!(op::Function, data::CuDeviceMatrix{T}) where {T}
         # write back results
         data[row,col] = shmem[row]
     end
+
+    return
 end
 
 rows = 5

--- a/examples/vadd.jl
+++ b/examples/vadd.jl
@@ -5,6 +5,7 @@ using Test
 function vadd(a, b, c)
     i = (blockIdx().x-1) * blockDim().x + threadIdx().x
     c[i] = a[i] + b[i]
+    return
 end
 
 dims = (3,4)

--- a/src/CUDAnative.jl
+++ b/src/CUDAnative.jl
@@ -5,6 +5,7 @@ using CUDAdrv
 using LLVM
 using LLVM.Interop
 
+using Pkg
 using Libdl
 
 const ext = joinpath(@__DIR__, "..", "deps", "ext.jl")

--- a/src/compiler/common.jl
+++ b/src/compiler/common.jl
@@ -26,25 +26,67 @@ function signature(ctx::CompilerContext)
 end
 
 
-abstract type AbstractCompilerError <: Exception end
-
-struct CompilerError <: AbstractCompilerError
+struct KernelError <: Exception
     ctx::CompilerContext
     message::String
+    help::Union{Nothing,String}
     bt::StackTraces.StackTrace
-    meta::Dict
 
-    CompilerError(ctx::CompilerContext, message="unknown error",
-                  bt=StackTraces.StackTrace(); kwargs...) =
-        new(ctx, message, bt, kwargs)
+    KernelError(ctx::CompilerContext, message::String, help=nothing;
+                bt=StackTraces.StackTrace()) =
+        new(ctx, message, help, bt)
 end
 
-function Base.showerror(io::IO, err::CompilerError)
-    print(io, "CompilerError: could not compile $(signature(err.ctx)); $(err.message)")
-    for (key,val) in err.meta
-        print(io, "\n- $key = $val")
-    end
+function Base.showerror(io::IO, err::KernelError)
+    println(io, "GPU compilation of $(signature(err.ctx)) failed")
+    println(io, "KernelError: $(err.message)")
+    println(io)
+    println(io, something(err.help, "Try inspecting the generated code with any of the @device_code_... macros."))
     Base.show_backtrace(io, err.bt)
+end
+
+
+struct InternalCompilerError <: Exception
+    ctx::CompilerContext
+    message::String
+    meta::Dict
+    InternalCompilerError(ctx, message; kwargs...) = new(ctx, message, kwargs)
+end
+
+function Base.showerror(io::IO, err::InternalCompilerError)
+    println(io, """CUDAnative.jl encountered an unexpected internal compiler error.
+                   Please file an issue attaching the following information, including the backtrace,
+                   as well as a reproducible example (if possible).""")
+
+    println(io, "\nInternalCompilerError: $(err.message)")
+
+    println(io, "\nCompiler invocation:")
+    for field in fieldnames(CompilerContext)
+        println(io, " - $field = $(repr(getfield(err.ctx, field)))")
+    end
+
+    if !isempty(err.meta)
+        println(io, "\nAdditional information:")
+        for (key,val) in err.meta
+            println(io, " - $key = $(repr(val))")
+        end
+    end
+
+    println(io, "\nInstalled packages:")
+    for (pkg,ver) in Pkg.installed()
+        println(io, " - $pkg = $ver")
+    end
+
+    println(io)
+    versioninfo(io)
+end
+
+macro compiler_assert(ex, ctx, kwargs...)
+    msg = "$ex, at $(__source__.file):$(__source__.line)"
+    return :($(esc(ex)) ? $(nothing)
+                        : throw(InternalCompilerError($(esc(ctx)), $msg;
+                                                      $(map(esc, kwargs)...)))
+            )
 end
 
 

--- a/src/compiler/common.jl
+++ b/src/compiler/common.jl
@@ -14,16 +14,13 @@ struct CompilerContext
     blocks_per_sm::Union{Nothing,Integer}
     maxregs::Union{Nothing,Integer}
 
-    # hacks
-    inner_f::Union{Nothing,Core.Function}
-
-    CompilerContext(f, tt, cap, kernel; inner_f=nothing, alias=nothing,
+    CompilerContext(f, tt, cap, kernel; alias=nothing,
                     minthreads=nothing, maxthreads=nothing, blocks_per_sm=nothing, maxregs=nothing) =
-        new(f, tt, cap, kernel, alias, minthreads, maxthreads, blocks_per_sm, maxregs, inner_f)
+        new(f, tt, cap, kernel, alias, minthreads, maxthreads, blocks_per_sm, maxregs)
 end
 
 function signature(ctx::CompilerContext)
-    fn = typeof(something(ctx.inner_f, ctx.f)).name.mt.name
+    fn = typeof(ctx.f).name.mt.name
     args = join(ctx.tt.parameters, ", ")
     return "$fn($(join(ctx.tt.parameters, ", ")))"
 end

--- a/src/compiler/driver.jl
+++ b/src/compiler/driver.jl
@@ -8,7 +8,7 @@ const compile_hook = Ref{Union{Nothing,Function}}(nothing)
 # Main entry point for compiling a Julia function + argtypes to a callable CUDA function
 function cufunction(dev::CuDevice, @nospecialize(f), @nospecialize(tt); kwargs...)
     CUDAnative.configured || error("CUDAnative.jl has not been configured; cannot JIT code.")
-    @assert isa(f, Core.Function)
+    isa(f, Core.Function) || throw(ArgumentError("Kernel argument to `cufunction` should be a function."))
 
     ctx = CompilerContext(f, tt, supported_capability(dev), true; kwargs...)
 

--- a/src/compiler/optim.jl
+++ b/src/compiler/optim.jl
@@ -134,7 +134,7 @@ end
 # generate a kernel wrapper to fix & improve argument passing
 function wrap_entry!(ctx::CompilerContext, mod::LLVM.Module, entry_f::LLVM.Function)
     entry_ft = eltype(llvmtype(entry_f)::LLVM.PointerType)::LLVM.FunctionType
-    @assert return_type(entry_ft) == LLVM.VoidType(JuliaContext())
+    @compiler_assert return_type(entry_ft) == LLVM.VoidType(JuliaContext()) ctx
 
     # filter out ghost types, which don't occur in the LLVM function signatures
     sig = Base.signature_type(ctx.f, ctx.tt)::Type
@@ -170,8 +170,8 @@ function wrap_entry!(ctx::CompilerContext, mod::LLVM.Module, entry_f::LLVM.Funct
             if codegen_t != wrapper_t
                 # the wrapper argument doesn't match the kernel parameter type.
                 # this only happens when codegen wants to pass a pointer.
-                @assert isa(codegen_t, LLVM.PointerType)
-                @assert eltype(codegen_t) == wrapper_t
+                @compiler_assert isa(codegen_t, LLVM.PointerType) ctx
+                @compiler_assert eltype(codegen_t) == wrapper_t ctx
 
                 # copy the argument value to a stack slot, and reference it.
                 ptr = alloca!(builder, wrapper_t)

--- a/src/compiler/validation.jl
+++ b/src/compiler/validation.jl
@@ -89,13 +89,7 @@ function backtrace(inst, bt = StackTraces.StackFrame[])
     # move up the call chain
     f = LLVM.parent(LLVM.parent(inst))
     callers = uses(f)
-    if isempty(callers)
-        # wrapping the kernel _does_ trigger a new debug info frame,
-        # so just get rid of the wrapper frame.
-        if !isempty(bt) && last(bt).func == :KernelWrapper
-            pop!(bt)
-        end
-    else
+    if !isempty(callers)
         # figure out the call sites of this instruction
         call_sites = unique(callers) do call
             # there could be multiple calls, originating from the same source location

--- a/src/execution.jl
+++ b/src/execution.jl
@@ -32,34 +32,6 @@ function method_age(f, tt)::UInt
     throw(MethodError(f, tt))
 end
 
-# generate kernel wrapper functions that ignore return values
-#
-# FIXME: we cannot use an ordinary splat for this, because that generates dynamic calls
-#        for certain types of arguments.
-#
-#        we also can't generate wrappers with a known amount of arguments, because `@cuda`
-#        supports splatting and doesn't know the inner function argument count
-
-struct KernelWrapper{F} <: Core.Function
-    f::F
-end
-
-for i in 0:13
-    params = Tuple(Symbol("param$j") for j in 1:i)
-    @eval begin
-        function (k::KernelWrapper)($(params...))
-            # TODO: call-site inlining; we now need to keep track of the inner function
-            #       for reflection usability reasons (look for `inner_f` in reflection.jl)
-            (k.f)($(params...))
-            return nothing
-        end
-    end
-end
-
-@generated function (::KernelWrapper{F})(params...) where {F}
-    @safe_fatal "invalid kernel call; too many arguments" kernel=F argc=length(params)
-end
-
 
 """
     @cuda [kwargs...] func(args...)
@@ -149,7 +121,7 @@ macro cuda(ex...)
     end
     push!(code.args,
         :(GC.@preserve($(vars...),
-                       _cuda(KernelWrapper($(esc(f))), $(esc(f)),
+                       _cuda($(esc(f)),
                              ($(map(esc, compiler_kwargs)...),),
                              ($(map(esc, call_kwargs)...),),
                              cudaconvert.(($(var_exprs...),))...,
@@ -170,8 +142,7 @@ end
 
 const agecache = Dict{UInt, UInt}()
 const compilecache = Dict{UInt, CuFunction}()
-@generated function _cuda(f::Core.Function, inner_f::Core.Function,
-                          compile_kwargs, call_kwargs, args...)
+@generated function _cuda(f::Core.Function, compile_kwargs, call_kwargs, args...)
     # we're in a generated function, so `args` are really types.
     # destructure into more appropriately-named variables
     t = args
@@ -207,7 +178,7 @@ const compilecache = Dict{UInt, CuFunction}()
         if haskey(agecache, key1)
             age = agecache[key1]
         else
-            age = method_age(inner_f, $t)
+            age = method_age(f, $t)
             agecache[key1] = age
         end
 
@@ -217,7 +188,7 @@ const compilecache = Dict{UInt, CuFunction}()
         if !haskey(compilecache, key2)
             try
                 compilecache[key2], _ =
-                    cufunction(device(ctx), f, $tt; inner_f=inner_f, compile_kwargs...)
+                    cufunction(device(ctx), f, $tt; compile_kwargs...)
             catch err
                 if isa(err, AbstractCompilerError)
                     rethrow(CompilationFailure(err))

--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -183,7 +183,7 @@ macro device_code_lowered(ex...)
     quote
         buf = Any[]
         function hook(ctx::CompilerContext)
-            append!(buf, code_lowered(something(ctx.inner_f, ctx.f), ctx.tt))
+            append!(buf, code_lowered(ctx.f, ctx.tt))
         end
         $(emit_hooked_compilation(:hook, ex...))
         buf
@@ -202,7 +202,7 @@ macro device_code_typed(ex...)
     quote
         buf = Any[]
         function hook(ctx::CompilerContext)
-            append!(buf, code_typed(something(ctx.inner_f, ctx.f), ctx.tt))
+            append!(buf, code_typed(ctx.f, ctx.tt))
         end
         $(emit_hooked_compilation(:hook, ex...))
         buf
@@ -219,7 +219,7 @@ See also: [`InteractiveUtils.@code_warntype`](@ref)
 """
 macro device_code_warntype(ex...)
     function hook(ctx::CompilerContext; io::IO=stdout, kwargs...)
-        code_warntype(io, something(ctx.inner_f, ctx.f), ctx.tt; kwargs...)
+        code_warntype(io, ctx.f, ctx.tt; kwargs...)
     end
     emit_hooked_compilation(hook, ex...)
 end
@@ -271,16 +271,16 @@ Evaluates the expression `ex` and dumps all intermediate forms of code to the di
 macro device_code(ex...)
     only(xs) = (@assert length(xs) == 1; first(xs))
     function hook(ctx::CompilerContext; dir::AbstractString)
-        fn = "$(typeof(something(ctx.inner_f, ctx.f)).name.mt.name)_$(globalUnique+1)"
+        fn = "$(typeof(ctx.f).name.mt.name)_$(globalUnique+1)"
         mkpath(dir)
 
         open(joinpath(dir, "$fn.lowered.jl"), "w") do io
-            code = only(code_lowered(something(ctx.inner_f, ctx.f), ctx.tt))
+            code = only(code_lowered(ctx.f, ctx.tt))
             println(io, code)
         end
 
         open(joinpath(dir, "$fn.typed.jl"), "w") do io
-            code = only(code_typed(something(ctx.inner_f, ctx.f), ctx.tt))
+            code = only(code_typed(ctx.f, ctx.tt))
             println(io, code)
         end
 

--- a/test/codegen.jl
+++ b/test/codegen.jl
@@ -18,7 +18,7 @@
     @test !occursin("!dbg", ir)
 
     @test CUDAnative.code_llvm(devnull, llvm_invalid_kernel, Tuple{}) == nothing
-    @test_throws CUDAnative.CompilerError CUDAnative.code_llvm(devnull, llvm_invalid_kernel, Tuple{}; kernel=true) == nothing
+    @test_throws CUDAnative.KernelError CUDAnative.code_llvm(devnull, llvm_invalid_kernel, Tuple{}; kernel=true) == nothing
 end
 
 @testset "exceptions" begin
@@ -195,7 +195,7 @@ end
 
     @test CUDAnative.code_ptx(devnull, ptx_valid_kernel, Tuple{}) == nothing
     @test CUDAnative.code_ptx(devnull, ptx_invalid_kernel, Tuple{}) == nothing
-    @test_throws CUDAnative.AbstractCompilerError CUDAnative.code_ptx(devnull, ptx_invalid_kernel, Tuple{}; kernel=true)
+    @test_throws CUDAnative.KernelError CUDAnative.code_ptx(devnull, ptx_invalid_kernel, Tuple{}; kernel=true)
 end
 
 @testset "child functions" begin
@@ -375,7 +375,7 @@ if VERSION >= v"0.7.0-beta.48"
     @eval error_recurse_outer(i) = i > 0 ? i : error_recurse_inner(i)
     @eval @noinline error_recurse_inner(i) = i < 0 ? i : error_recurse_outer(i)
 
-    @test_throws_message(CUDAnative.CompilerError, CUDAnative.code_llvm(error_recurse_outer, Tuple{Int})) do msg
+    @test_throws_message(CUDAnative.KernelError, CUDAnative.code_llvm(error_recurse_outer, Tuple{Int})) do msg
         occursin("recursion is currently not supported", msg) &&
         occursin("[1] error_recurse_outer", msg) &&
         occursin("[2] error_recurse_inner", msg) &&
@@ -411,7 +411,7 @@ end
 @testset "non-isbits arguments" begin
     @eval error_use_nonbits(i) = sink(unsafe_trunc(Int,i))
 
-    @test_throws_message(CUDAnative.CompilerError, CUDAnative.code_ptx(error_use_nonbits, Tuple{BigInt})) do msg
+    @test_throws_message(CUDAnative.KernelError, CUDAnative.code_ptx(error_use_nonbits, Tuple{BigInt})) do msg
         occursin("passing and using non-bitstype argument", msg) &&
         occursin("BigInt", msg)
     end

--- a/test/device/array.jl
+++ b/test/device/array.jl
@@ -57,6 +57,8 @@ end
         if i <= length(input)
             output[i] = Float64(input[i])   # force conversion upon setindex!
         end
+
+        return
     end
 
     input = round.(rand(Float32, dims) * 100)
@@ -77,6 +79,7 @@ end
             acc += elem
         end
         output[1] = acc
+        return
     end
 
     input = round.(rand(Float32, dims) * 100)
@@ -115,6 +118,8 @@ end
         if i <= length(sub)
             sub[i] = i
         end
+
+        return
     end
 
     array = zeros(Int64, 100)
@@ -144,6 +149,7 @@ end
 @testset "ldg" begin
     @eval function array_cached_load(a, b, i)
         b[i] = ldg(a, i)
+        return
     end
 
     buf = IOBuffer()

--- a/test/device/codegen.jl
+++ b/test/device/codegen.jl
@@ -92,7 +92,7 @@ end
     @eval sass_invalid_kernel() = 1
 
     @test CUDAnative.code_sass(devnull, sass_valid_kernel, Tuple{}) == nothing
-    @test_throws CUDAnative.CompilerError CUDAnative.code_sass(devnull, sass_invalid_kernel, Tuple{})
+    @test_throws CUDAnative.KernelError CUDAnative.code_sass(devnull, sass_invalid_kernel, Tuple{})
 end
 
 end

--- a/test/device/intrinsics.jl
+++ b/test/device/intrinsics.jl
@@ -29,6 +29,7 @@ end
 
     @eval function kernel_math_log10(a, i)
         a[1] = CUDAnative.log10(i)
+        return
     end
 
     @cuda kernel_math_log10(buf, Float32(100))
@@ -74,6 +75,7 @@ end
     # c argument promotions
     @eval function issue_231(A)
         @cuprintf("%f %f\n", A[1], A[1])
+        return
     end
     x = CuTestArray(ones(2, 2))
     _, out = @grab_output begin
@@ -138,6 +140,8 @@ end
         s[t] = d[t]
         sync_threads()
         d[t] = s[tr]
+
+        return
     end
 
     a = rand(Float32, n)
@@ -155,6 +159,8 @@ end
     s[t] = d[t]
     sync_threads()
     d[t] = s[tr]
+
+    return
 end
 @testset "parametrically typed" for T in [Int32, Int64, Float32, Float64]
     a = rand(T, n)
@@ -169,6 +175,7 @@ end
     @eval function kernel_shmem_dynamic_alignment(v0::T, n) where {T}
         shared = CUDAnative.@cuDynamicSharedMem(T, n)
         @inbounds shared[Cuint(1)] = v0
+        return
     end
 
     n = 32
@@ -193,6 +200,8 @@ end
         s2[t] = 2*d[t]
         sync_threads()
         d[t] = s[tr]
+
+        return
     end
 
     a = rand(Float32, n)
@@ -213,6 +222,8 @@ end
     s2[t] = d[t]
     sync_threads()
     d[t] = s[tr]
+
+    return
 end
 @testset "parametrically typed" for T in [Int32, Int64, Float32, Float64]
     a = rand(T, n)
@@ -227,6 +238,7 @@ end
     @eval function kernel_shmem_static_alignment(v0::T) where {T}
         shared = CUDAnative.@cuStaticSharedMem(T, 32)
         @inbounds shared[Cuint(1)] = v0
+        return
     end
 
     @cuda kernel_shmem_static_alignment((0f0, 0f0, 0f0))
@@ -255,6 +267,8 @@ end
         sb[t] = b[t]
         sync_threads()
         b[t] = sb[tr]
+
+        return
     end
 
     a = rand(Float32, n)
@@ -284,6 +298,8 @@ end
         sb[t] = b[t]
         sync_threads()
         b[t] = sb[tr]
+
+        return
     end
 
     a = rand(Float32, n)
@@ -324,6 +340,7 @@ n = 14
     if t <= n
         d[t] += shfl_down(d[t], n÷2)
     end
+    return
 end
 @testset "down" for T in [Int32, Int64, Float32, Float64, AddableTuple]
     a = T[T(i) for i in 1:n]
@@ -362,6 +379,7 @@ end
         if threadIdx().x == 1
             a[1] = vote
         end
+        return
     end
 
     len = 4
@@ -379,6 +397,7 @@ end
         if threadIdx().x == 1
             a[1] = vote
         end
+        return
     end
 
     @cuda threads=2 kernel_vote_any(d_a, 1)
@@ -399,6 +418,7 @@ end
         if threadIdx().x == 1
             a[1] = vote
         end
+        return
     end
 
     @cuda threads=2 kernel_vote_all(d_a, 1)

--- a/test/device/pointer.jl
+++ b/test/device/pointer.jl
@@ -31,6 +31,7 @@ end
 @testset "indexing" begin
     @eval function issue_221(src, dst)
         unsafe_store!(dst, CUDAnative.unsafe_cached_load(src, 4))
+        return
     end
 
     T = Complex{Int8}

--- a/test/perf/launch_overhead/cudanative.jl
+++ b/test/perf/launch_overhead/cudanative.jl
@@ -7,7 +7,10 @@ using CUDAdrv, CUDAnative
 using Statistics
 using Printf
 
-kernel_dummy(ptr) = Base.pointerset(ptr, 0f0, Int(blockIdx().x), 8)
+function kernel_dummy(ptr)
+    Base.pointerset(ptr, 0f0, Int(blockIdx().x), 8)
+    return
+end
 
 const len = 1000
 const ITERATIONS = 100

--- a/test/util.jl
+++ b/test/util.jl
@@ -42,6 +42,7 @@ macro on_device(ex)
         let
             @eval function $kernel()
                 $ex
+                return
             end
 
             @cuda $kernel()


### PR DESCRIPTION
This is a breaking change, requiring a `return [nothing]` at the end of every kernel again.