### PR TITLE
Remove unused arguments to demoted exceptions

### DIFF
--- a/src/compiler/irgen.jl
+++ b/src/compiler/irgen.jl
@@ -32,7 +32,7 @@ function raise_exception(insblock::BasicBlock, ex::Value)
     let builder = Builder(ctx)
         position!(builder, insblock)
 
-        cuprintf!(builder, "ERROR: an unknown exception occurred$cuprintf_endline")
+        cuprintf!(builder, "ERROR: an unknown exception occurred$cuprintf_endline during kernel execution")
         call!(builder, trap)
 
         dispose(builder)
@@ -301,7 +301,7 @@ function remove_throw!(mod::LLVM.Module)
                         position!(builder, entry)
 
                         desc = replace(ex, '_'=>' ')
-                        cuprintf!(builder, "ERROR: a $ex exception occurred$cuprintf_endline")
+                        cuprintf!(builder, "ERROR: a $ex exception occurred$cuprintf_endline during kernel execution")
                         call!(builder, trap)
                         ret!(builder)
 

--- a/src/compiler/irgen.jl
+++ b/src/compiler/irgen.jl
@@ -300,7 +300,7 @@ function remove_throw!(mod::LLVM.Module)
                 # replace uses of the original function
                 for use in uses(f)
                     call = user(use)
-                    @compiler_assert isa(call, LLVM.CallInst) ctx
+                    @assert isa(call, LLVM.CallInst)
                     let builder = Builder(ctx)
                         position!(builder, call)
                         call!(builder, f′)
@@ -310,8 +310,9 @@ function remove_throw!(mod::LLVM.Module)
                 end
 
                 # remove the original function or declaration
-                @compiler_assert isempty(uses(f)) ctx
+                @assert isempty(uses(f))
                 unsafe_delete!(mod, f)
+
 
                 changed = true
             end

--- a/test/codegen.jl
+++ b/test/codegen.jl
@@ -360,6 +360,15 @@ end
     test_name(codegen_closure, "ptxcall_codegen_renamed"; kernel=true, alias="codegen_renamed")
 end
 
+@testset "exception arguments" begin
+    @eval function codegen_exception_arguments(a)
+        unsafe_store!(a, trunc(Int, unsafe_load(a)))
+        return
+    end
+
+    CUDAnative.code_ptx(codegen_exception_arguments, Tuple{Ptr{Float64}})
+end
+
 end
 
 


### PR DESCRIPTION
Can as well keep on piling up hacks onto the exception rewriting.
Really wanting to remove it all and switch to Cassette overdubbing of `Core.throw`.

```
julia> broadcast(val->trunc(UInt,val), CuArray([1.1]))
1-element CuArray{UInt64,1}:
 0x0000000000000001

julia> broadcast(val->trunc(UInt,val), CuArray([-1.]))
1-element CuArray{UInt64,1}:
ERROR: an unknown exception occurred
 0x0000000000000000
```