### PR TITLE
Add a kernel object abstraction: low-level alternative to at-cuda

### DIFF
--- a/src/compiler/driver.jl
+++ b/src/compiler/driver.jl
@@ -19,7 +19,7 @@ function cufunction(dev::CuDevice, @nospecialize(f), @nospecialize(tt); kwargs..
         globalUnique = previous_globalUnique
     end
 
-    (module_asm, module_entry) = compile_function(ctx)
+    (module_asm, module_entry) = compile(ctx)
 
     # enable debug options based on Julia's debug setting
     jit_options = Dict{CUDAdrv.CUjit_option,Any}()
@@ -50,7 +50,7 @@ end
 # Not to be used directly, see `cufunction` instead.
 # FIXME: this pipeline should be partially reusable from eg. code_llvm
 #        also, does the kernel argument belong in the compiler context?
-function compile_function(ctx::CompilerContext; strip_ir_metadata::Bool=false)
+function compile(ctx::CompilerContext; strip_ir_metadata::Bool=false)
     ## high-level code generation (Julia AST)
 
     @debug "(Re)compiling function" ctx

--- a/src/compiler/driver.jl
+++ b/src/compiler/driver.jl
@@ -31,18 +31,6 @@ function cufunction(dev::CuDevice, @nospecialize(f), @nospecialize(tt); kwargs..
     cuda_mod = CuModule(module_asm, jit_options)
     cuda_fun = CuFunction(cuda_mod, module_entry)
 
-    @debug begin
-        attr = attributes(cuda_fun)
-        bin_ver = VersionNumber(divrem(attr[CUDAdrv.FUNC_ATTRIBUTE_BINARY_VERSION],10)...)
-        ptx_ver = VersionNumber(divrem(attr[CUDAdrv.FUNC_ATTRIBUTE_PTX_VERSION],10)...)
-        regs = attr[CUDAdrv.FUNC_ATTRIBUTE_NUM_REGS]
-        local_mem = attr[CUDAdrv.FUNC_ATTRIBUTE_LOCAL_SIZE_BYTES]
-        shared_mem = attr[CUDAdrv.FUNC_ATTRIBUTE_SHARED_SIZE_BYTES]
-        constant_mem = attr[CUDAdrv.FUNC_ATTRIBUTE_CONST_SIZE_BYTES]
-        """Compiled $f to PTX $ptx_ver for SM $bin_ver using $regs registers.
-           Memory usage: $local_mem B local, $shared_mem B shared, $constant_mem B constant"""
-    end
-
     return cuda_fun, cuda_mod
 end
 

--- a/src/execution.jl
+++ b/src/execution.jl
@@ -113,11 +113,10 @@ Affecting the kernel launch:
 Note that, contrary to with CUDA C, you can invoke the same kernel multiple times with
 different compilation parameters. New code will be generated automatically.
 
-The `func` argument should be a valid Julia function. Its return values will be ignored, by
-means of a wrapper. The function will be compiled to a CUDA function upon first use, and to
-a certain extent arguments will be converted and managed automatically (see
-[`cudaconvert`](@ref)). Finally, a call to `cudacall` is performed, scheduling the compiled
-function for execution on the GPU.
+The `func` argument should be a valid Julia function that should not return anything. It
+will be compiled to a CUDA function upon first use, and to a certain extent arguments will
+be converted and managed automatically (see [`cudaconvert`](@ref)). Finally, a call to
+`CUDAdrv.cudacall` is performed, scheduling the compiled function for execution on the GPU.
 """
 macro cuda(ex...)
     # destructure the `@cuda` expression

--- a/src/execution.jl
+++ b/src/execution.jl
@@ -161,9 +161,6 @@ const compilecache = Dict{UInt, Kernel}()
     # destructure into more appropriately-named variables
     t = args
     sig = (f, t...)
-    args = (:f, (:( args[$i] ) for i in 1:length(args))...)
-
-    # finalize types
     tt = Base.to_tuple_type(t)
 
     precomp_key = hash(sig)  # precomputable part of the keys
@@ -220,7 +217,6 @@ end
     quote
         Base.@_inline_meta
 
-        # call the kernel
         cudacall(kernel.fun, $call_tt, $(call_args...); call_kwargs...)
     end
 end

--- a/src/execution.jl
+++ b/src/execution.jl
@@ -146,7 +146,7 @@ macro cuda(ex...)
                 $cuda_args = cudaconvert.(($(var_exprs...),))
                 $kernel = compile_function($(esc(f)), $cuda_args...;
                                            $(map(esc, compiler_kwargs)...))
-                launch_kernel($kernel, $cuda_args...; $(map(esc, call_kwargs)...))
+                $kernel($cuda_args...; $(map(esc, call_kwargs)...))
             end
          end)
     return code
@@ -189,7 +189,7 @@ const compilecache = Dict{UInt, Kernel}()
     end
 end
 
-@generated function launch_kernel(kernel::Kernel{F}, args...; call_kwargs...) where F
+@generated function (kernel::Kernel{F})(args...; call_kwargs...) where F
     # we're in a generated function, so `args` are really types.
     # destructure into more appropriately-named variables
     t = args

--- a/src/execution.jl
+++ b/src/execution.jl
@@ -166,7 +166,7 @@ kernel to determine the launch configuration:
     GC.@preserve args begin
         kernel_args = cudaconvert.(args)
         kernel = CUDAnative.compile_function(f, kernel_args; compilation_kwargs)
-        kernel(kernel_args; launch_kwargs)
+        kernel(kernel_args...; launch_kwargs)
     end
 """
 macro cuda(ex...)

--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -72,7 +72,7 @@ function code_ptx(io::IO, @nospecialize(func::Core.Function), @nospecialize(type
     code_ptx(io, ctx)
 end
 function code_ptx(io::IO, ctx::CompilerContext; strip_ir_metadata::Bool=true)
-    ptx,_ = compile_function(ctx; strip_ir_metadata=strip_ir_metadata)
+    ptx,_ = compile(ctx; strip_ir_metadata=strip_ir_metadata)
     # TODO: this code contains all the functions in the call chain,
     #       is it possible to implement `dump_module`?
     print(io, ptx)
@@ -106,7 +106,7 @@ function code_sass(io::IO, ctx::CompilerContext)
         error("Your CUDA installation does not provide ptxas or cuobjdump, both of which are required for code_sass")
     end
 
-    ptx,_ = compile_function(ctx)
+    ptx,_ = compile(ctx)
 
     fn = tempname()
     gpu = "sm_$(ctx.cap.major)$(ctx.cap.minor)"

--- a/test/codegen.jl
+++ b/test/codegen.jl
@@ -399,7 +399,7 @@ end
     @test occursin(r"\[2\] .+foobar", bt_msg)
 end
 
-# some validation happens in compile_function, which is called by code_ptx
+# some validation happens in `compile`, which is called by `code_ptx`
 
 @testset "non-isbits arguments" begin
     foobar(i) = sink(unsafe_trunc(Int,i))

--- a/test/device/execution.jl
+++ b/test/device/execution.jl
@@ -22,6 +22,12 @@ end
 @test_throws MethodError @cuda dummy(1)
 
 
+@testset "low-level interface" begin
+    kernel = CUDAnative.compile_function(dummy)
+    dummy()
+end
+
+
 @testset "compilation params" begin
     @cuda dummy()
 


### PR DESCRIPTION
Fixes https://github.com/JuliaGPU/CUDAnative.jl/issues/120
Should give the necessary reflection tools to tackle problems like https://github.com/JuliaGPU/CuArrays.jl/issues/160

Example usage:

```julia
args = (d_a, d_b, d_c)
GC.@preserve args begin
    kernel_args = cudaconvert.(args)
    kernel = CUDAnative.compile_function(vadd, kernel_args...)
    if CUDAnative.registers(kernel) > 42 #=TODO: CUDAdrv.registers(device()) =#
        threads = 1
    else
        threads = 2
    end
    kernel(kernel_args...; threads=threads)
end
```