### PR TITLE
Fix broken links in documetation

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,7 +22,7 @@ documentation:
   image: juliagpu/julia:v1.0-cuda
   variables:
     DOCUMENTER_DEBUG: "true"
-    TRAVIS_REPO_SLUG: "github.com/JuliaGPU/CUDAnative.jl.git"
+    TRAVIS_REPO_SLUG: "JuliaGPU/CUDAnative.jl"
     TRAVIS_BRANCH: $CI_COMMIT_REF_NAME
     TRAVIS_TAG: $CI_COMMIT_TAG
   dependencies:


### PR DESCRIPTION
The documentation has links to `github.com/github.com/JuliaGPU/CUDAnative.jl.git/.../..`, which are broken.
Changing `TRAVIS_REPO_SLUG` fixes the links. Remotely related to https://github.com/JuliaDocs/Documenter.jl/pull/837