### PR TITLE
use nvdisasm instead of cuobjdump

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -141,7 +141,7 @@ function main()
     config[:libdevice] == nothing && build_error("Available CUDA toolchain does not provide libdevice")
     ## optional
     config[:cuobjdump] = find_cuda_binary("cuobjdump", toolkit_dirs)
-    config[:nvdisasm] = find_cuda_binary("nvdiasm", toolkit_dirs)
+    config[:nvdisasm] = find_cuda_binary("nvdisasm", toolkit_dirs)
     config[:ptxas] = find_cuda_binary("ptxas", toolkit_dirs)
 
     config[:configured] = true

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -141,6 +141,7 @@ function main()
     config[:libdevice] == nothing && build_error("Available CUDA toolchain does not provide libdevice")
     ## optional
     config[:cuobjdump] = find_cuda_binary("cuobjdump", toolkit_dirs)
+    config[:nvdisasm] = find_cuda_binary("nvdiasm", toolkit_dirs)
     config[:ptxas] = find_cuda_binary("ptxas", toolkit_dirs)
 
     config[:configured] = true

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -140,7 +140,6 @@ function main()
     config[:libdevice] = find_libdevice(config[:target_support], toolkit_dirs)
     config[:libdevice] == nothing && build_error("Available CUDA toolchain does not provide libdevice")
     ## optional
-    config[:cuobjdump] = find_cuda_binary("cuobjdump", toolkit_dirs)
     config[:nvdisasm] = find_cuda_binary("nvdisasm", toolkit_dirs)
     config[:ptxas] = find_cuda_binary("ptxas", toolkit_dirs)
 

--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -102,8 +102,9 @@ function code_sass(io::IO, ctx::CompilerContext)
     if !ctx.kernel
         error("Can only generate SASS code for kernel functions")
     end
-    if ptxas === nothing || cuobjdump === nothing
-        error("Your CUDA installation does not provide ptxas or cuobjdump, both of which are required for code_sass")
+    # TODO: Fall back to cuobjdump
+    if ptxas === nothing || nvdisam === nothing
+        error("Your CUDA installation does not provide ptxas or nvdisasm, both of which are required for code_sass")
     end
 
     ptx,_ = compile(ctx)
@@ -115,7 +116,7 @@ function code_sass(io::IO, ctx::CompilerContext)
     # TODO: see how `nvvp` extracts SASS code when doing PC sampling, and copy that.
     Base.run(`$ptxas --gpu-name $gpu --output-file $fn --input-as-string $ptx`)
     try
-        print(io, read(`$cuobjdump --dump-sass $fn`, String))
+        print(io, read(`$nvdisam --print-code --print-line-info $fn`, String))
     finally
         rm(fn)
     end

--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -115,7 +115,17 @@ function code_sass(io::IO, ctx::CompilerContext)
     # TODO: see how `nvvp` extracts SASS code when doing PC sampling, and copy that.
     Base.run(`$ptxas --gpu-name $gpu --output-file $fn --input-as-string $ptx`)
     try
-        print(io, read(`$nvdisam --print-code --print-line-info $fn`, String))
+        cmd = `$nvdisasm --print-code --print-line-info $fn`
+        for line in readlines(cmd)
+            # nvdisasm output is pretty verbose;
+            # perform some clean-up and make it look like @code_native
+            line = replace(line, r"/\*[0-9a-f]{4}\*/" => "        ") # strip inst addr
+            line = replace(line, r"^[ ]{30}" => "   ")               # reduce leading spaces
+            line = replace(line, r"[\s+]//##" => ";")                # change line info tag
+            line = replace(line, r"^\." => "\n.")                    # break before new BBs
+            line = replace(line, r"; File \"(.+?)\", line (\d+)" => s"; Location \1:\2") # rename line info
+            println(io, line)
+        end
     finally
         rm(fn)
     end

--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -102,8 +102,7 @@ function code_sass(io::IO, ctx::CompilerContext)
     if !ctx.kernel
         error("Can only generate SASS code for kernel functions")
     end
-    # TODO: Fall back to cuobjdump
-    if ptxas === nothing || nvdisam === nothing
+    if ptxas === nothing || nvdisasm === nothing
         error("Your CUDA installation does not provide ptxas or nvdisasm, both of which are required for code_sass")
     end
 


### PR DESCRIPTION
`nvdisasm` provides more information by default, as an example function calls are resolved to the symbol instead of the pointer, and has a couple of useful options.
This defaults to printing available line information and only printing the code and not the data section.

The other options that are useful are:

- `--print-life-ranges`: Printing life ranges for registers
- `--output-control-flow-graph`: Get a CFG of the kernels