### PR TITLE
Various improvements to docs

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -15,7 +15,6 @@ makedocs(
         "Library" => [
             "lib/compilation.md",
             "lib/reflection.md",
-            "lib/profiling.md",
             "Device Code" => [
                 "lib/device/intrinsics.md",
                 "lib/device/array.md",

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,7 +2,7 @@ using Documenter, CUDAnative
 
 makedocs(
     modules = [CUDAnative],
-    format = Documenter.HTML(),
+    format = Documenter.HTML(prettyurls = get(ENV, "CI", nothing) == "true"),
     sitename = "CUDAnative.jl",
     pages = [
         "Home"    => "index.md",

--- a/docs/src/lib/compilation.md
+++ b/docs/src/lib/compilation.md
@@ -2,6 +2,15 @@
 
 ```@docs
 CUDAnative.@cuda
+CUDAnative.cufunction
+CUDAnative.Kernel
+CUDAnative.compile
 CUDAnative.cudaconvert
 CUDAnative.nearest_warpsize
+```
+
+## Devices
+
+```@docs
+CUDAnative.device!
 ```

--- a/docs/src/lib/profiling.md
+++ b/docs/src/lib/profiling.md
@@ -1,5 +1,0 @@
-# Profiling
-
-```@docs
-CUDAnative.@profile
-```

--- a/docs/src/lib/reflection.md
+++ b/docs/src/lib/reflection.md
@@ -28,3 +28,12 @@ CUDAnative.@device_code_ptx
 CUDAnative.@device_code_sass
 CUDAnative.@device_code
 ```
+
+## Version and related queries
+
+```@docs
+CUDAnative.version
+CUDAnative.maxthreads
+CUDAnative.registers
+CUDAnative.memory
+```

--- a/docs/src/man/performance.md
+++ b/docs/src/man/performance.md
@@ -8,18 +8,19 @@ describe how to do so, and what to be careful about.
 ## Profiling
 
 When optimizing code, it is important to know what to optimize. Luckily, the CUDA toolkit
-ships an excellent profiler, `nvprof`, with `nvpp` as the Eclipse-based UI. The CUDAnative
+ships an excellent profiler, `nvprof`, with `nvvp` as the Eclipse-based UI. The CUDAnative
 compiler is fully compatible with these tools, and generates the required line number
 information to debug performance issues. To generate line number information, invoke Julia
-with the command-line option `-g1`. Using `-g2` puts the PTX JIT in debug mode, which
-significantly lowers performance of GPU code and currently does not improve debugging.
+with the command-line option `-g1` (the default option). Using `-g2` puts the PTX JIT in
+debug mode, which significantly lowers performance of GPU code and currently does not
+improve debugging.
 
-CUDAdrv exports a `@profile` macro. However, it does not serve the same purpose as
-`Base.@profile`. Rather, it instructs the CUDA profiler to start right before the first
-kernel launch. This avoids profiling during the time Julia or CUDAnative precompile code,
-and result in a much more compact timeline view. If you want to use this feature, disable
-the `nvprof`/`nvvp` option to "Start profiling at application start". As with all Julia
-code, also perform a warm-up iteration without the profiler activated.
+Traces collected with these tools might be very large and sparse, because they capture the
+entire application including e.g. kernel compilation or initial data uploads. To avoid this,
+run the above profilers with the option "Start profiling at application start" disabled
+(`--profile-from-start off` with `nvprof`), make your application perform a warm-up
+iteration, and wrap subsequent iterations with `CUDAdrv.@profile`. This macro instructs any
+active profiler to start collecting information, resulting in much more focused traces.
 
 For true source-level profiling akin to `Base.@profile`, look at `nvvp`'s PC Sampling View
 (requires compute capability >= 5.2, CUDA >= 7.5). In the future, we might have a

--- a/docs/src/man/performance.md
+++ b/docs/src/man/performance.md
@@ -14,7 +14,7 @@ information to debug performance issues. To generate line number information, in
 with the command-line option `-g1`. Using `-g2` puts the PTX JIT in debug mode, which
 significantly lowers performance of GPU code and currently does not improve debugging.
 
-Although CUDAnative exports a `@profile` macro, it does not serve the same purpose as
+CUDAdrv exports a `@profile` macro. However, it does not serve the same purpose as
 `Base.@profile`. Rather, it instructs the CUDA profiler to start right before the first
 kernel launch. This avoids profiling during the time Julia or CUDAnative precompile code,
 and result in a much more compact timeline view. If you want to use this feature, disable

--- a/src/execution.jl
+++ b/src/execution.jl
@@ -136,6 +136,15 @@ Base.getindex(r::CuRefValue) = r.x
 Adapt.adapt_structure(to::Adaptor, r::Base.RefValue) = CuRefValue(adapt(to, r[]))
 
 # convenience function
+"""
+    cudaconvert(x)
+
+This function is called for every argument to be passed to a kernel, allowing it to be
+converted to a GPU-friendly format. By default, the function does nothing and returns the
+input object `x` as-is.
+For `CuArray` objects, a corresponding `CuDeviceArray` object in global space is returned,
+which implements GPU-compatible array functionality.
+"""
 cudaconvert(arg) = adapt(Adaptor(), arg)
 
 
@@ -270,18 +279,6 @@ when function changes, or when different types or keyword arguments are provided
     end
 end
 
-"""
-    (::Kernel)(args...; kwargs...)
-
-Low-level interface to call a compiled kernel, passing GPU-compatible arguments in `args`.
-For a higher-level interface, use [`@cuda`](@ref).
-
-The following keyword arguments are supported:
-- threads (defaults to 1)
-- blocks (defaults to 1)
-- shmem (defaults to 0)
-- stream (defaults to the default stream)
-"""
 @generated function (kernel::Kernel{F,TT})(args...; call_kwargs...) where {F,TT}
     sig = Base.signature_type(F, TT)
     args = (:F, (:( args[$i] ) for i in 1:length(args))...)
@@ -310,6 +307,21 @@ The following keyword arguments are supported:
     end
 end
 
+# There doesn't seem to be a way to access the documentation for the call-syntax,
+# so attach it to the type
+"""
+    (::Kernel)(args...; kwargs...)
+
+Low-level interface to call a compiled kernel, passing GPU-compatible arguments in `args`.
+For a higher-level interface, use [`@cuda`](@ref).
+
+The following keyword arguments are supported:
+- threads (defaults to 1)
+- blocks (defaults to 1)
+- shmem (defaults to 0)
+- stream (defaults to the default stream)
+"""
+Kernel
 
 ## other
 

--- a/src/execution.jl
+++ b/src/execution.jl
@@ -142,8 +142,9 @@ Adapt.adapt_structure(to::Adaptor, r::Base.RefValue) = CuRefValue(adapt(to, r[])
 This function is called for every argument to be passed to a kernel, allowing it to be
 converted to a GPU-friendly format. By default, the function does nothing and returns the
 input object `x` as-is.
-For `CuArray` objects, a corresponding `CuDeviceArray` object in global space is returned,
-which implements GPU-compatible array functionality.
+
+Do not add methods to this function, but instead extend the underlying Adapt.jl package and
+register methods for the the `CUDAnative.Adaptor` type.
 """
 cudaconvert(arg) = adapt(Adaptor(), arg)
 


### PR DESCRIPTION
I'm finally converting from old CUDArt to the newer infrastructure. I noticed a few places where I could help by improving the documentation. Now the only warnings when you include `make.jl` are related to `@ref`s to things like `InteractiveUtils.@code_llvm`, which AFAICT Documenter does not support.

The least satisfying part of this is the fact that I changed the "attachment point" for the documentation for `(::Kernel)(args...; kwargs...)`. The former choice was the most logical, but with a minute or two of experimentation I was unable to find a way to obtain that docstring from within the REPL. Consequently I moved it to the type itself, so that it can be obtained with `?CUDAnative.Kernel`.
