### PR TITLE
Don't initialize CUDA when querying for the version.

### DIFF
--- a/src/init.jl
+++ b/src/init.jl
@@ -15,6 +15,7 @@ const device_contexts = Dict{CuDevice,CuContext}()
 #
 # feel free to open a PR adding additional API calls, if you have a specific use for them.
 const preinit_apicalls = Set{Symbol}([
+    :cuDriverGetVersion,
     # device calls, commonly used to determine the most appropriate device
     :cuDeviceGet,
     :cuDeviceGetAttribute,


### PR DESCRIPTION
The version happens during precompilation, and might consequently cause context
creation in the parent process to fail when eg. using process exclusive mode.