### PR TITLE
Implement heap-allocated boxes

### DIFF
--- a/src/compiler/common.jl
+++ b/src/compiler/common.jl
@@ -13,9 +13,13 @@ struct CompilerContext
     blocks_per_sm::Union{Nothing,Integer}
     maxregs::Union{Nothing,Integer}
 
-    CompilerContext(f, tt, cap, kernel;
-                    minthreads=nothing, maxthreads=nothing, blocks_per_sm=nothing, maxregs=nothing) =
-        new(f, tt, cap, kernel, minthreads, maxthreads, blocks_per_sm, maxregs)
+    function CompilerContext(f, tt, cap, kernel;
+                             minthreads=nothing, maxthreads=nothing,
+                             blocks_per_sm=nothing, maxregs=nothing)
+        ctx = new(f, tt, cap, kernel, minthreads, maxthreads, blocks_per_sm, maxregs)
+        check_method(ctx)
+        ctx
+    end
 end
 
 # global context reference

--- a/src/compiler/driver.jl
+++ b/src/compiler/driver.jl
@@ -71,8 +71,10 @@ function compile(ctx::CompilerContext; strip_ir_metadata::Bool=false)
 
     runtime = load_runtime(ctx.cap)
     if need_library(runtime)
-        link_runtime!(ctx, mod, runtime)
+        link_library!(ctx, mod, runtime)
     end
+
+    prepare_execution!(ctx, mod)
 
     check_invocation(ctx, entry)
 

--- a/src/compiler/driver.jl
+++ b/src/compiler/driver.jl
@@ -71,7 +71,7 @@ function compile(ctx::CompilerContext; strip_ir_metadata::Bool=false)
 
     runtime = load_runtime(ctx.cap)
     if need_library(runtime)
-        link_library!(ctx, mod, runtime)
+        link_runtime!(ctx, mod, runtime)
     end
 
     check_invocation(ctx, entry)

--- a/src/compiler/driver.jl
+++ b/src/compiler/driver.jl
@@ -49,8 +49,6 @@ function compile(ctx::CompilerContext; strip_ir_metadata::Bool=false)
 
     @debug "(Re)compiling function" ctx
 
-    check_method(ctx)
-
 
     ## low-level code generation (LLVM IR)
 

--- a/src/compiler/irgen.jl
+++ b/src/compiler/irgen.jl
@@ -243,7 +243,7 @@ function irgen(ctx::CompilerContext)
     llvmfn *= "_$globalUnique"
     LLVM.name!(entry, llvmfn)
 
-    # minimal optimization to get rid of useless generated code (llvmcall, kernel wrapper)
+    # minimal required optimization
     ModulePassManager() do pm
         global global_ctx
         global_ctx = ctx

--- a/src/compiler/mcgen.jl
+++ b/src/compiler/mcgen.jl
@@ -19,6 +19,74 @@ function machine(cap::VersionNumber, triple::String)
     return tm
 end
 
+# final preparations for the module to be compiled to PTX
+# these passes should not be run when e.g. compiling to write to disk.
+function prepare_execution!(ctx::CompilerContext, mod::LLVM.Module)
+    let pm = ModulePassManager()
+        global global_ctx
+        global_ctx = ctx
+
+        global_optimizer!(pm)
+        global_dce!(pm)
+
+        add!(pm, ModulePass("ResolveCPUReferences", resolve_cpu_references!))
+
+        strip_dead_prototypes!(pm)
+
+        run!(pm, mod)
+        dispose(pm)
+    end
+
+    return
+end
+
+# some Julia code contains references to objects in the CPU run-time,
+# without actually using the contents or functionality of those objects.
+#
+# prime example are type tags, which reference the address of the allocated type.
+# since those references are ephemeral, we can't eagerly resolve and emit them in the IR,
+# but at the same time the GPU can't resolve them at run-time.
+#
+# this pass performs that resolution at link time.
+function resolve_cpu_references!(mod::LLVM.Module)
+    ctx = global_ctx::CompilerContext
+    changed = false
+
+    for f in functions(mod)
+        fn = LLVM.name(f)
+        if isdeclaration(f) && intrinsic_id(f) == 0 && startswith(fn, "jl_")
+            # eagerly resolve the address of the binding
+            address = ccall(:jl_cglobal, Any, (Any, Any), fn, UInt)
+            dereferenced = unsafe_load(address)
+            dereferenced = LLVM.ConstantInt(dereferenced, JuliaContext())
+
+            function replace_bindings!(value)
+                changed = false
+                for use in uses(value)
+                    target = user(use)
+                    if isa(target, LLVM.ConstantExpr)
+                        # recurse
+                        changed |= replace_bindings!(target)
+                    elseif isa(target, LLVM.LoadInst)
+                        # resolve
+                        replace_uses!(target, dereferenced)
+                        changed = true
+                    end
+                end
+                changed
+            end
+
+            changed |= replace_bindings!(f)
+
+            if isempty(uses(f))
+                unsafe_delete!(mod, f)
+            end
+        end
+    end
+
+    return changed
+end
+
 function mcgen(ctx::CompilerContext, mod::LLVM.Module, f::LLVM.Function)
     tm = machine(ctx.cap, triple(mod))
 

--- a/src/compiler/optim.jl
+++ b/src/compiler/optim.jl
@@ -355,8 +355,8 @@ function lower_relocations!(mod::LLVM.Module)
             # look-up the current type tag
             type_name = m.captures[1]
             type_sym = Symbol("jl_$(type_name)_type")
-            type_ptr = @eval cglobal($(QuoteNode(type_sym)))
-            type_tag = unsafe_load(convert(Ptr{UInt64}, type_ptr))
+            type_ptr = ccall(:jl_cglobal, Any, (Any, Any), type_sym, UInt64)
+            type_tag = unsafe_load(type_ptr)
 
             # replace uses of the relocation with a constant value
             val = LLVM.ConstantInt(type_tag, JuliaContext())

--- a/src/compiler/rtlib.jl
+++ b/src/compiler/rtlib.jl
@@ -162,3 +162,12 @@ function load_runtime(cap)
         end
     end
 end
+
+function link_runtime!(ctx::CompilerContext, mod::LLVM.Module, lib::LLVM.Module)
+    link_library!(ctx, mod, lib)
+
+    ModulePassManager() do pm
+        add!(pm, ModulePass("LowerRelocations", lower_relocations!))
+        run!(pm, mod)
+    end
+end

--- a/src/compiler/rtlib.jl
+++ b/src/compiler/rtlib.jl
@@ -162,12 +162,3 @@ function load_runtime(cap)
         end
     end
 end
-
-function link_runtime!(ctx::CompilerContext, mod::LLVM.Module, lib::LLVM.Module)
-    link_library!(ctx, mod, lib)
-
-    ModulePassManager() do pm
-        add!(pm, ModulePass("LowerRelocations", lower_relocations!))
-        run!(pm, mod)
-    end
-end

--- a/src/device/runtime_intrinsics.jl
+++ b/src/device/runtime_intrinsics.jl
@@ -103,6 +103,15 @@ end
 compile(report_exception_frame, Nothing, (Cint, Ptr{Cchar}, Ptr{Cchar}, Cint))
 compile(report_exception_name, Nothing, (Ptr{Cchar},))
 
+function bounds_error_unboxed_int(data, vt, i)
+    @cuprintf("ERROR: a bounds error occurred during kernel execution.")
+    # FIXME: have this call emit_exception somehow
+    return
+end
+
+compile(bounds_error_unboxed_int, Nothing, (Ptr{Cvoid}, Any, Csize_t);
+        llvm_name="jl_bounds_error_unboxed_int")
+
 
 ## GC
 
@@ -128,7 +137,7 @@ end
 compile(gc_pool_alloc, Any, (Csize_t,), T_prjlvalue)
 
 
-## boxing
+## boxing and unboxing
 
 const tag_type = UInt
 const tag_size = sizeof(tag_type)

--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -28,7 +28,6 @@ function code_llvm(io::IO, @nospecialize(func::Core.Function), @nospecialize(typ
                    kernel::Bool=false, kwargs...)
     tt = Base.to_tuple_type(types)
     ctx = CompilerContext(func, tt, cap, kernel; kwargs...)
-    check_method(ctx)
     code_llvm(io, ctx; optimize=optimize, dump_module=dump_module,
               strip_ir_metadata=strip_ir_metadata)
 end
@@ -68,7 +67,6 @@ function code_ptx(io::IO, @nospecialize(func::Core.Function), @nospecialize(type
                   strip_ir_metadata::Bool=true, kwargs...)
     tt = Base.to_tuple_type(types)
     ctx = CompilerContext(func, tt, cap, kernel; kwargs...)
-    check_method(ctx)
     code_ptx(io, ctx)
 end
 function code_ptx(io::IO, ctx::CompilerContext; strip_ir_metadata::Bool=true)
@@ -95,7 +93,6 @@ function code_sass(io::IO, @nospecialize(func::Core.Function), @nospecialize(typ
                    cap::VersionNumber=current_capability(), kernel::Bool=true, kwargs...)
     tt = Base.to_tuple_type(types)
     ctx = CompilerContext(func, tt, cap, kernel; kwargs...)
-    check_method(ctx)
     code_sass(io, ctx)
 end
 function code_sass(io::IO, ctx::CompilerContext)

--- a/test/device/array.jl
+++ b/test/device/array.jl
@@ -93,22 +93,6 @@ end
 end
 
 @testset "bounds checking" begin
-    function oob_1d(array)
-        return array[1]
-    end
-
-    ir = sprint(io->CUDAnative.code_llvm(io, oob_1d, (CuDeviceArray{Int,1,AS.Global},)))
-    @test !occursin("julia_throw_boundserror", ir)
-    @test occursin("ptx_report_exception", ir)
-
-    function oob_2d(array)
-        return array[1, 1]
-    end
-
-    ir = sprint(io->CUDAnative.code_llvm(io, oob_2d, (CuDeviceArray{Int,2,AS.Global},)))
-    @test !occursin("julia_throw_boundserror", ir)
-    @test occursin("ptx_report_exception", ir)
-
     @testset "#313" begin
         function kernel(dest)
             dest[1] = 1


### PR DESCRIPTION
Implements `jl_box_uint64` which makes it possible to execute the following without our hacky `replace_throw!` pass:

```julia
function foo(i, ptr)
    for Ri_base in 0:1:i
        unsafe_store!(ptr, 0)
    end
    nothing
end
```

( this constructs a lot of boxes when creating exception objects )

Should also make it possible to eg. store into `CuArray{Any}` vectors, although it's pretty unclear there who owns that memory.

Additional difficulty: type tag values change across Julia sessions, so to avoid rebuilding the CUDAnative runtime each time I emit calls to `late_jl_uint64_type` and resolve those to actual values when linking the library.