### PR TITLE
Fix safe_fn

### DIFF
--- a/src/compiler/irgen.jl
+++ b/src/compiler/irgen.jl
@@ -11,7 +11,7 @@ function module_setup(mod::LLVM.Module)
 end
 
 # make function names safe for PTX
-safe_fn(fn::String) = replace(fn, r"[^aA-zZ0-9_]"=>"_")
+safe_fn(fn::String) = replace(fn, r"[^A-Za-z0-9_]"=>"_")
 safe_fn(f::Core.Function) = safe_fn(String(typeof(f).name.mt.name))
 safe_fn(f::LLVM.Function) = safe_fn(LLVM.name(f))
 

--- a/test/codegen.jl
+++ b/test/codegen.jl
@@ -466,10 +466,18 @@ end
     end
 end
 
-@testset "safe_fn" begin
-    name = "julia_^
-    @test CUDAnative.safe_fn(name) != name 
+@testset "Correct mangling of ^" begin
+    name = "julia_^"
+    @test CUDAnative.safe_fn(name) != name
+
+    @eval @noinline $(Symbol("dummy_^"))(x) = x
+
+    @eval kernel_341(a,i) = (@inbounds a[1]=$(Symbol("dummy_^"))(a[1]); nothing)
+
+    @test CUDAnative.code_sass(kernel_341, Tuple{CuDeviceArray{Int,2,AS.Global},Int})
 end
+
+@testset
 
 
 ############################################################################################

--- a/test/codegen.jl
+++ b/test/codegen.jl
@@ -466,6 +466,9 @@ end
     end
 end
 
+@testset "safe_fn" begin
+    name = "julia_^
+    @test safe_fn(name) != name 
 end
 
 

--- a/test/codegen.jl
+++ b/test/codegen.jl
@@ -468,7 +468,7 @@ end
 
 @testset "safe_fn" begin
     name = "julia_^
-    @test safe_fn(name) != name 
+    @test CUDAnative.safe_fn(name) != name 
 end
 
 

--- a/test/codegen.jl
+++ b/test/codegen.jl
@@ -466,18 +466,18 @@ end
     end
 end
 
-@testset "Correct mangling of ^" begin
+@testset "function name mangling" begin
     name = "julia_^"
     @test CUDAnative.safe_fn(name) != name
 
     @eval @noinline $(Symbol("dummy_^"))(x) = x
 
-    @eval kernel_341(a,i) = (@inbounds a[1]=$(Symbol("dummy_^"))(a[1]); nothing)
+    @eval kernel_341(ptr) = (@inbounds unsafe_store!(ptr, $(Symbol("dummy_^"))(unsafe_load(ptr))); nothing)
 
-    @test CUDAnative.code_sass(kernel_341, Tuple{CuDeviceArray{Int,2,AS.Global},Int})
+    CUDAnative.code_sass(devnull, kernel_341, Tuple{Ptr{Int}})
 end
 
-@testset
+end
 
 
 ############################################################################################


### PR DESCRIPTION
`safe_fn` did not correctly mangle function names containing `^` due to a regex bug.
Found with @vchuravy.