### PR TITLE
Check for OOM when doing malloc.

### DIFF
--- a/src/device/runtime_intrinsics.jl
+++ b/src/device/runtime_intrinsics.jl
@@ -125,6 +125,10 @@ end
 
 function gc_pool_alloc(sz::Csize_t)
     ptr = malloc(sz)
+    if ptr == C_NULL
+        @cuprintf("ERROR: Out of dynamic GPU memory (trying to allocate %i bytes)\n", sz)
+        throw(OutOfMemoryError())
+    end
     return unsafe_pointer_to_objref(ptr)
 end
 


### PR DESCRIPTION
Addresses https://github.com/JuliaGPU/CUDAnative.jl/issues/340

Crashes on `-g2` with the following MWE though:

```
using CUDAnative, StaticArrays

function knl!()
  r_a = MArray{Tuple{4}, Float32}(undef)

  for k in 1:4
    @inbounds r_a[k] = 0
  end

  nothing
end

@cuda threads=(5, 5) blocks=4000 knl!()

using CUDAdrv
CUDAdrv.synchronize()
```