### PR TITLE
Support atomics

### DIFF
--- a/examples/reduce/benchmark.jl
+++ b/examples/reduce/benchmark.jl
@@ -32,7 +32,7 @@ benchmark_cpu = @benchmarkable begin
 open(joinpath(@__DIR__, "reduce.jl.ptx"), "w") do f
     CUDAnative.code_ptx(f, reduce_grid, Tuple{typeof(+), CuDeviceVector{Int32,AS.Global},
                                               CuDeviceVector{Int32,AS.Global}, Int32};
-                        cap=v"6.1.0")
+                        cap=cap)
 end
 
 benchmark_gpu = @benchmarkable begin

--- a/examples/reduce/reduce.cu
+++ b/examples/reduce/reduce.cu
@@ -24,7 +24,7 @@ inline void check_code(cudaError_t code, const char *file, int line)
 __inline__ __device__
 int sumReduce_warp(int val) {
   for (int offset = warpSize/2; offset > 0; offset /= 2) 
-    val += __shfl_down(val, offset);
+    val += __shfl_down_sync(0xFFFFFFFF, val, offset);
   return val;
 }
 

--- a/examples/reduce/reduce.jl
+++ b/examples/reduce/reduce.jl
@@ -58,7 +58,6 @@ end
 # Reduce an array across a complete grid
 function reduce_grid(op::F, input::CuDeviceVector{T}, output::CuDeviceVector{T},
                      len::Integer) where {F<:Function,T}
-
     # TODO: neutral element depends on the operator (see Base's 2 and 3 argument `reduce`)
     val = zero(T)
 

--- a/src/device/array.jl
+++ b/src/device/array.jl
@@ -53,7 +53,10 @@ CuDeviceVector{T,A}(len::Integer,               p::DevicePtr{T,A}) where {T,A}  
 ## getters
 
 Base.pointer(a::CuDeviceArray) = a.ptr
+Base.pointer(a::CuDeviceArray, i::Integer) =
+    pointer(a) + (i - 1) * Base.elsize(a)
 
+Base.elsize(::Type{<:CuDeviceArray{T}}) where {T} = sizeof(T)
 Base.size(g::CuDeviceArray) = g.shape
 Base.length(g::CuDeviceArray) = prod(g.shape)
 

--- a/src/device/cuda.jl
+++ b/src/device/cuda.jl
@@ -9,6 +9,7 @@ include(joinpath("cuda", "warp_shuffle.jl"))
 include(joinpath("cuda", "output.jl"))
 include(joinpath("cuda", "assertion.jl"))
 include(joinpath("cuda", "memory_dynamic.jl"))
+include(joinpath("cuda", "atomics.jl"))
 include(joinpath("cuda", "misc.jl"))
 
 # functionality from libdevice

--- a/src/device/cuda/atomics.jl
+++ b/src/device/cuda/atomics.jl
@@ -157,3 +157,43 @@ for A in (AS.Generic, AS.Global, AS.Shared)
         end
     end
 end
+
+
+#
+# Documentation
+#
+
+"""
+    atomic_add!(ptr::DevicePtr{T}, val::T)
+
+Reads the value `old` located at address `ptr`, computes `old+val`, and stores the result
+back to memory at the same address. These operations are performed in one atomic
+transaction. The function returns `old`.
+
+This operation is supported for values of type Int32, Int64, UInt32, UInt64, and Float32.
+Additionally, on GPU hardware with compute capability 6.0+, values of type Float64 are
+supported.
+"""
+atomic_add!
+
+"""
+    atomic_inc!(ptr::DevicePtr{T}, val::T)
+
+Reads the value `old` located at address `ptr`, computes `((old >= val) ? 0 : (old+1))`, and
+stores the result back to memory at the same address. These three operations are performed
+in one atomic transaction. The function returns `old`.
+
+This operation is only supported for values of type Int32.
+"""
+atomic_inc!
+
+"""
+    atomic_dec!(ptr::DevicePtr{T}, val::T)
+
+Reads the value `old` located at address `ptr`, computes `(((old == 0) | (old > val)) ? val
+: (old-1) )`, and stores the result back to memory at the same address. These three
+operations are performed in one atomic transaction. The function returns `old`.
+
+This operation is only supported for values of type Int32.
+"""
+atomic_dec!

--- a/src/device/cuda/atomics.jl
+++ b/src/device/cuda/atomics.jl
@@ -1,8 +1,24 @@
 # Atomic Functions (B.12)
 
 # TODO:
-# - _system and _block versions (see CUDA programming guide)
+# - scoped atomics: _system and _block versions (see CUDA programming guide, sm_60+)
+#   https://github.com/Microsoft/clang/blob/86d4513d3e0daa4d5a29b0b1de7c854ca15f9fe5/test/CodeGen/builtins-nvptx.c#L293
 # - atomic_cas!
+
+
+#
+# LLVM
+#
+
+# common arithmetic operations on integers using LLVM instructions
+#
+# > 8.6.6. atomicrmw Instruction
+# >
+# > nand is not supported. The other keywords are supported for i32 and i64 types, with the
+# > following restrictions.
+# >
+# > - The pointer must be either a global pointer, a shared pointer, or a generic pointer
+# >   that points to either the global address space or the shared address space.
 
 @generated function llvm_atomic(::Val{binop}, ptr::DevicePtr{T,A}, val::T, ::Val{ordering}) where
                                {binop, T, A, ordering}
@@ -46,15 +62,6 @@ const binops = Dict(
 const aquire = LLVM.API.LLVMAtomicOrderingAcquire
 const aquire_release = LLVM.API.LLVMAtomicOrderingAcquireRelease
 
-# common arithmetic operations on integers using LLVM instructions
-#
-# > 8.6.6. atomicrmw Instruction
-# >
-# > nand is not supported. The other keywords are supported for i32 and i64 types, with the
-# > following restrictions.
-# >
-# > - The pointer must be either a global pointer, a shared pointer, or a generic pointer
-# >   that points to either the global address space or the shared address space.
 for T in (Int32, Int64, UInt32, UInt64)
     ops = [:xchg, :add, :sub, :and, :or, :xor, :max, :min]
 
@@ -74,21 +81,48 @@ for T in (Int32, Int64, UInt32, UInt64)
     end
 end
 
+
+#
+# NVVM
+#
+
 # floating-point operations using NVVM intrinsics
-# TODO: LLVM supports _some_ atomic_rmw ops with floating-point types
-#       does NVPTX support those? why use NVVM intrinsics?
+
 for A in (AS.Generic, AS.Global, AS.Shared)
     # declare float @llvm.nvvm.atomic.load.add.f32.p0f32(float* address, float val)
     # declare float @llvm.nvvm.atomic.load.add.f32.p1f32(float addrspace(1)* address, float val)
     # declare float @llvm.nvvm.atomic.load.add.f32.p3f32(float addrspace(3)* address, float val)
+    #
+    # FIXME: these only works on sm_60+, but we can't verify that for now
     # declare double @llvm.nvvm.atomic.load.add.f64.p0f64(double* address, double val)
     # declare double @llvm.nvvm.atomic.load.add.f64.p1f64(double addrspace(1)* address, double val)
     # declare double @llvm.nvvm.atomic.load.add.f64.p3f64(double addrspace(3)* address, double val)
     for T in (Float32, Float64)
         nb = sizeof(T)*8
         intr = "llvm.nvvm.atomic.load.add.f$nb.p$(convert(Int, A))f$nb"
-        @eval @inline atomic_add!(ptr::DevicePtr{$T,$A}, val::$T) =
-            ccall($intr, llvmcall, $T, (DevicePtr{$T,$A}, $T), ptr, val)
+
+        if VERSION >= v"999" # FIXME: JuliaLang/julia#31624
+            @eval @inline atomic_add!(ptr::DevicePtr{$T,$A}, val::$T) =
+                ccall($intr, llvmcall, $T, (DevicePtr{$T,$A}, $T), ptr, val)
+        else
+            import Base.Sys: WORD_SIZE
+            if T == Float32
+                T_val = "float"
+            else
+                T_val = "double"
+            end
+            if A == AS.Generic
+                T_ptr = "$(T_val)*"
+            else
+                T_ptr = "$(T_val) addrspace($(convert(Int, A)))*"
+            end
+            @eval @inline atomic_add!(ptr::DevicePtr{$T,$A}, val::$T) = Base.llvmcall(
+                $("declare $T_val @$intr($T_ptr, $T_val)",
+                  "%ptr = inttoptr i$WORD_SIZE %0 to $T_ptr
+                   %rv = call $T_val @$intr($T_ptr %ptr, $T_val %1)
+                   ret $T_val %rv"), $T,
+                Tuple{DevicePtr{$T,$A}, $T}, ptr, val)
+        end
     end
 
     # declare i32 @llvm.nvvm.atomic.load.inc.32.p0i32(i32* address, i32 val)
@@ -101,9 +135,25 @@ for A in (AS.Generic, AS.Global, AS.Shared)
     for T in (Int32,), op in (:inc, :dec)
         nb = sizeof(T)*8
         intr = "llvm.nvvm.atomic.load.$op.$nb.p$(convert(Int, A))i$nb"
-
         fn = Symbol("atomic_$(op)!")
-        @eval @inline $fn(ptr::DevicePtr{$T,$A}, val::$T) =
-            ccall($intr, llvmcall, $T, (DevicePtr{$T,$A}, $T), ptr, val)
+
+        if VERSION >= v"999" # FIXME: JuliaLang/julia#31624
+            @eval @inline $fn(ptr::DevicePtr{$T,$A}, val::$T) =
+                ccall($intr, llvmcall, $T, (DevicePtr{$T,$A}, $T), ptr, val)
+        else
+            import Base.Sys: WORD_SIZE
+            T_val = "i32"
+            if A == AS.Generic
+                T_ptr = "$(T_val)*"
+            else
+                T_ptr = "$(T_val) addrspace($(convert(Int, A)))*"
+            end
+            @eval @inline $fn(ptr::DevicePtr{$T,$A}, val::$T) = Base.llvmcall(
+                $("declare $T_val @$intr($T_ptr, $T_val)",
+                  "%ptr = inttoptr i$WORD_SIZE %0 to $T_ptr
+                   %rv = call $T_val @$intr($T_ptr %ptr, $T_val %1)
+                   ret $T_val %rv"), $T,
+                Tuple{DevicePtr{$T,$A}, $T}, ptr, val)
+        end
     end
 end

--- a/src/device/cuda/atomics.jl
+++ b/src/device/cuda/atomics.jl
@@ -167,9 +167,19 @@ end
 ## documentation
 
 """
+    atomic_xchg!(ptr::DevicePtr{T}, val::T)
+
+Reads the value `old` located at address `ptr` and stores `val` at the same address. These
+operations are performed in one atomic transaction. The function returns `old`.
+
+This operation is supported for values of type Int32, Int64, UInt32 and UInt64.
+"""
+atomic_xchg!
+
+"""
     atomic_add!(ptr::DevicePtr{T}, val::T)
 
-Reads the value `old` located at address `ptr`, computes `old+val`, and stores the result
+Reads the value `old` located at address `ptr`, computes `old + val`, and stores the result
 back to memory at the same address. These operations are performed in one atomic
 transaction. The function returns `old`.
 
@@ -178,6 +188,72 @@ Additionally, on GPU hardware with compute capability 6.0+, values of type Float
 supported.
 """
 atomic_add!
+
+"""
+    atomic_sub!(ptr::DevicePtr{T}, val::T)
+
+Reads the value `old` located at address `ptr`, computes `old - val`, and stores the result
+back to memory at the same address. These operations are performed in one atomic
+transaction. The function returns `old`.
+
+This operation is supported for values of type Int32, Int64, UInt32 and UInt64.
+"""
+atomic_sub!
+
+"""
+    atomic_and!(ptr::DevicePtr{T}, val::T)
+
+Reads the value `old` located at address `ptr`, computes `old & val`, and stores the result
+back to memory at the same address. These operations are performed in one atomic
+transaction. The function returns `old`.
+
+This operation is supported for values of type Int32, Int64, UInt32 and UInt64.
+"""
+atomic_and!
+
+"""
+    atomic_or!(ptr::DevicePtr{T}, val::T)
+
+Reads the value `old` located at address `ptr`, computes `old | val`, and stores the result
+back to memory at the same address. These operations are performed in one atomic
+transaction. The function returns `old`.
+
+This operation is supported for values of type Int32, Int64, UInt32 and UInt64.
+"""
+atomic_or!
+
+"""
+    atomic_xor!(ptr::DevicePtr{T}, val::T)
+
+Reads the value `old` located at address `ptr`, computes `old ⊻ val`, and stores the result
+back to memory at the same address. These operations are performed in one atomic
+transaction. The function returns `old`.
+
+This operation is supported for values of type Int32, Int64, UInt32 and UInt64.
+"""
+atomic_xor!
+
+"""
+    atomic_min!(ptr::DevicePtr{T}, val::T)
+
+Reads the value `old` located at address `ptr`, computes `min(old, val)`, and stores the
+result back to memory at the same address. These operations are performed in one atomic
+transaction. The function returns `old`.
+
+This operation is supported for values of type Int32, Int64, UInt32 and UInt64.
+"""
+atomic_min!
+
+"""
+    atomic_max!(ptr::DevicePtr{T}, val::T)
+
+Reads the value `old` located at address `ptr`, computes `min(old, val)`, and stores the
+result back to memory at the same address. These operations are performed in one atomic
+transaction. The function returns `old`.
+
+This operation is supported for values of type Int32, Int64, UInt32 and UInt64.
+"""
+atomic_max!
 
 """
     atomic_inc!(ptr::DevicePtr{T}, val::T)
@@ -227,11 +303,16 @@ const inplace_ops = Dict(
     @atomic a[I] = op(a[I], val)
     @atomic a[I] ...= val
 
-Atomically perform a sequence of operations that loads an array element `a[I]`, performs
-the operation `op` on that value and a second value `val`, and writes the result back to
-the array. This sequence can be written out as a regular assignment, in which case the
-same array element should be used in the left and right hand side of the assignment, or
-as an in-place application of a known operator.
+Atomically perform a sequence of operations that loads an array element `a[I]`, performs the
+operation `op` on that value and a second value `val`, and writes the result back to the
+array. This sequence can be written out as a regular assignment, in which case the same
+array element should be used in the left and right hand side of the assignment, or as an
+in-place application of a known operator. In both cases, the array reference should be pure
+and not induce any side-effects.
+
+!!! warn
+    This interface is experimental, and might change without warning.  Use the lower-level
+    `atomic_...!` functions for a stable API.
 """
 macro atomic(ex)
     # decode assignment and call

--- a/src/device/cuda/atomics.jl
+++ b/src/device/cuda/atomics.jl
@@ -1,0 +1,109 @@
+# Atomic Functions (B.12)
+
+# TODO:
+# - _system and _block versions (see CUDA programming guide)
+# - atomic_cas!
+
+@generated function llvm_atomic(::Val{binop}, ptr::DevicePtr{T,A}, val::T, ::Val{ordering}) where
+                               {binop, T, A, ordering}
+    T_val = convert(LLVMType, T)
+    T_ptr = convert(LLVMType, DevicePtr{T,A})
+    T_actual_ptr = LLVM.PointerType(T_val)
+
+    llvm_f, _ = create_function(T_val, [T_ptr, T_val])
+
+    Builder(JuliaContext()) do builder
+        entry = BasicBlock(llvm_f, "entry", JuliaContext())
+        position!(builder, entry)
+
+        actual_ptr = inttoptr!(builder, parameters(llvm_f)[1], T_actual_ptr)
+
+        rv = atomic_rmw!(builder, binop,
+                         actual_ptr, parameters(llvm_f)[2],
+                         ordering, #=single_threaded=# false)
+
+        ret!(builder, rv)
+    end
+
+    call_function(llvm_f, T, Tuple{DevicePtr{T,A}, T}, :((ptr,val)))
+end
+
+const binops = Dict(
+    :xchg  => LLVM.API.LLVMAtomicRMWBinOpXchg,
+    :add   => LLVM.API.LLVMAtomicRMWBinOpAdd,
+    :sub   => LLVM.API.LLVMAtomicRMWBinOpSub,
+    :and   => LLVM.API.LLVMAtomicRMWBinOpAnd,
+    :or    => LLVM.API.LLVMAtomicRMWBinOpOr,
+    :xor   => LLVM.API.LLVMAtomicRMWBinOpXor,
+    :max   => LLVM.API.LLVMAtomicRMWBinOpMax,
+    :min   => LLVM.API.LLVMAtomicRMWBinOpMin,
+    :umax  => LLVM.API.LLVMAtomicRMWBinOpUMax,
+    :umin  => LLVM.API.LLVMAtomicRMWBinOpUMin
+)
+
+# all atomic operations have acquire and/or release semantics,
+# depending on whether they load or store values (mimics Base)
+const aquire = LLVM.API.LLVMAtomicOrderingAcquire
+const aquire_release = LLVM.API.LLVMAtomicOrderingAcquireRelease
+
+# common arithmetic operations on integers using LLVM instructions
+#
+# > 8.6.6. atomicrmw Instruction
+# >
+# > nand is not supported. The other keywords are supported for i32 and i64 types, with the
+# > following restrictions.
+# >
+# > - The pointer must be either a global pointer, a shared pointer, or a generic pointer
+# >   that points to either the global address space or the shared address space.
+for T in (Int32, Int64, UInt32, UInt64)
+    ops = [:xchg, :add, :sub, :and, :or, :xor, :max, :min]
+
+    ASs = Union{AS.Generic, AS.Global, AS.Shared}
+
+    for op in ops
+        # LLVM distinguishes signedness in the operation, not the integer type.
+        rmw =  if T <: Unsigned && (op == :max || op == :min)
+            Symbol("u$op")
+        else
+            Symbol("$op")
+        end
+
+        fn = Symbol("atomic_$(op)!")
+        @eval @inline $fn(ptr::DevicePtr{$T,<:$ASs}, val::$T) =
+            llvm_atomic($(Val(binops[rmw])), ptr, val, Val(aquire_release))
+    end
+end
+
+# floating-point operations using NVVM intrinsics
+# TODO: LLVM supports _some_ atomic_rmw ops with floating-point types
+#       does NVPTX support those? why use NVVM intrinsics?
+for A in (AS.Generic, AS.Global, AS.Shared)
+    # declare float @llvm.nvvm.atomic.load.add.f32.p0f32(float* address, float val)
+    # declare float @llvm.nvvm.atomic.load.add.f32.p1f32(float addrspace(1)* address, float val)
+    # declare float @llvm.nvvm.atomic.load.add.f32.p3f32(float addrspace(3)* address, float val)
+    # declare double @llvm.nvvm.atomic.load.add.f64.p0f64(double* address, double val)
+    # declare double @llvm.nvvm.atomic.load.add.f64.p1f64(double addrspace(1)* address, double val)
+    # declare double @llvm.nvvm.atomic.load.add.f64.p3f64(double addrspace(3)* address, double val)
+    for T in (Float32, Float64)
+        nb = sizeof(T)*8
+        intr = "llvm.nvvm.atomic.load.add.f$nb.p$(convert(Int, A))f$nb"
+        @eval @inline atomic_add!(ptr::DevicePtr{$T,$A}, val::$T) =
+            ccall($intr, llvmcall, $T, (DevicePtr{$T,$A}, $T), ptr, val)
+    end
+
+    # declare i32 @llvm.nvvm.atomic.load.inc.32.p0i32(i32* address, i32 val)
+    # declare i32 @llvm.nvvm.atomic.load.inc.32.p1i32(i32 addrspace(1)* address, i32 val)
+    # declare i32 @llvm.nvvm.atomic.load.inc.32.p3i32(i32 addrspace(3)* address, i32 val)
+    #
+    # declare i32 @llvm.nvvm.atomic.load.dec.32.p0i32(i32* address, i32 val)
+    # declare i32 @llvm.nvvm.atomic.load.dec.32.p1i32(i32 addrspace(1)* address, i32 val)
+    # declare i32 @llvm.nvvm.atomic.load.dec.32.p3i32(i32 addrspace(3)* address, i32 val)
+    for T in (Int32,), op in (:inc, :dec)
+        nb = sizeof(T)*8
+        intr = "llvm.nvvm.atomic.load.$op.$nb.p$(convert(Int, A))i$nb"
+
+        fn = Symbol("atomic_$(op)!")
+        @eval @inline $fn(ptr::DevicePtr{$T,$A}, val::$T) =
+            ccall($intr, llvmcall, $T, (DevicePtr{$T,$A}, $T), ptr, val)
+    end
+end

--- a/test/device/cuda.jl
+++ b/test/device/cuda.jl
@@ -578,4 +578,69 @@ end
 
 ############################################################################################
 
+@testset "atomics" begin
+
+@testset "atomic_add" begin
+    types = [Int32, Int64, UInt32, UInt64, Float32]
+    cap >= v"6.0" && push!(types, Float64)
+
+    @testset for T in types
+        a = CuArray{T}([zero(T)])
+
+        function kernel(a, b)
+            CUDAnative.atomic_add!(pointer(a), b)
+            return
+        end
+
+        @cuda threads=1024 kernel(a, one(T))
+        @test a[1] == T(1024)
+    end
+end
+
+@testset "atomic_sub" begin
+    @testset for T in [Int32, Int64, UInt32, UInt64]
+        a = CuArray{T}([T(2048)])
+
+        function kernel(a, b)
+            CUDAnative.atomic_sub!(pointer(a), b)
+            return
+        end
+
+        @cuda threads=1024 kernel(a, one(T))
+        @test a[1] == T(1024)
+    end
+end
+
+@testset "atomic_inc" begin
+    @testset for T in [Int32]
+        a = CuArray{T}([zero(T)])
+
+        function kernel(a, b)
+            CUDAnative.atomic_inc!(pointer(a), b)
+            return
+        end
+
+        @cuda threads=768 kernel(a, T(512))
+        @test a[1] == T(255)
+    end
+end
+
+@testset "atomic_dec" begin
+    @testset for T in [Int32]
+        a = CuArray{T}([T(1024)])
+
+        function kernel(a, b)
+            CUDAnative.atomic_dec!(pointer(a), b)
+            return
+        end
+
+        @cuda threads=256 kernel(a, T(512))
+        @test a[1] == T(257)
+    end
+end
+
+end
+
+############################################################################################
+
 end

--- a/test/device/cuda.jl
+++ b/test/device/cuda.jl
@@ -578,14 +578,14 @@ end
 
 ############################################################################################
 
-@testset "atomics" begin
+@testset "atomics (low-level)" begin
 
 @testset "atomic_add" begin
     types = [Int32, Int64, UInt32, UInt64, Float32]
     cap >= v"6.0" && push!(types, Float64)
 
     @testset for T in types
-        a = CuArray{T}([zero(T)])
+        a = CuTestArray([zero(T)])
 
         function kernel(a, b)
             CUDAnative.atomic_add!(pointer(a), b)
@@ -593,13 +593,13 @@ end
         end
 
         @cuda threads=1024 kernel(a, one(T))
-        @test a[1] == T(1024)
+        @test Array(a)[1] == T(1024)
     end
 end
 
 @testset "atomic_sub" begin
     @testset for T in [Int32, Int64, UInt32, UInt64]
-        a = CuArray{T}([T(2048)])
+        a = CuTestArray([T(2048)])
 
         function kernel(a, b)
             CUDAnative.atomic_sub!(pointer(a), b)
@@ -607,13 +607,13 @@ end
         end
 
         @cuda threads=1024 kernel(a, one(T))
-        @test a[1] == T(1024)
+        @test Array(a)[1] == T(1024)
     end
 end
 
 @testset "atomic_inc" begin
     @testset for T in [Int32]
-        a = CuArray{T}([zero(T)])
+        a = CuTestArray([zero(T)])
 
         function kernel(a, b)
             CUDAnative.atomic_inc!(pointer(a), b)
@@ -621,13 +621,13 @@ end
         end
 
         @cuda threads=768 kernel(a, T(512))
-        @test a[1] == T(255)
+        @test Array(a)[1] == T(255)
     end
 end
 
 @testset "atomic_dec" begin
     @testset for T in [Int32]
-        a = CuArray{T}([T(1024)])
+        a = CuTestArray([T(1024)])
 
         function kernel(a, b)
             CUDAnative.atomic_dec!(pointer(a), b)
@@ -635,7 +635,129 @@ end
         end
 
         @cuda threads=256 kernel(a, T(512))
-        @test a[1] == T(257)
+        @test Array(a)[1] == T(257)
+    end
+end
+
+end
+
+@testset "atomics (high-level)" begin
+
+@testset "add" begin
+    types = [Int32, Int64, UInt32, UInt64, Float32]
+    cap >= v"6.0" && push!(types, Float64)
+
+    @testset for T in types
+        a = CuTestArray([zero(T)])
+
+        function kernel(T, a)
+            @atomic a[1] = a[1] + T(1)
+            @atomic a[1] += T(1)
+            return
+        end
+
+        @cuda threads=1024 kernel(T, a)
+        @test Array(a)[1] == T(2048)
+    end
+end
+
+@testset "sub" begin
+    @testset for T in [Int32, Int64, UInt32, UInt64]
+        a = CuTestArray([T(4096)])
+
+        function kernel(T, a)
+            @atomic a[1] = a[1] - T(1)
+            @atomic a[1] -= T(1)
+            return
+        end
+
+        @cuda threads=1024 kernel(T, a)
+        @test Array(a)[1] == T(2048)
+    end
+end
+
+@testset "and" begin
+    @testset for T in [Int32, Int64, UInt32, UInt64]
+        a = CuTestArray([~zero(T), ~zero(T)])
+
+        function kernel(T, a)
+            i = threadIdx().x
+            mask = ~(T(1) << (i-1))
+            @atomic a[1] = a[1] & mask
+            @atomic a[2] &= mask
+            return
+        end
+
+        @cuda threads=8*sizeof(T) kernel(T, a)
+        @test Array(a)[1] == zero(T)
+        @test Array(a)[2] == zero(T)
+    end
+end
+
+@testset "or" begin
+    @testset for T in [Int32, Int64, UInt32, UInt64]
+        a = CuTestArray([zero(T), zero(T)])
+
+        function kernel(T, a)
+            i = threadIdx().x
+            mask = T(1) << (i-1)
+            @atomic a[1] = a[1] | mask
+            @atomic a[2] |= mask
+            return
+        end
+
+        @cuda threads=8*sizeof(T) kernel(T, a)
+        @test Array(a)[1] == ~zero(T)
+        @test Array(a)[2] == ~zero(T)
+    end
+end
+
+@testset "xor" begin
+    @testset for T in [Int32, Int64, UInt32, UInt64]
+        a = CuTestArray([zero(T), zero(T)])
+
+        function kernel(T, a)
+            i = threadIdx().x
+            mask = T(1) << ((i-1)%(8*sizeof(T)))
+            @atomic a[1] = a[1] ⊻ mask
+            @atomic a[2] ⊻= mask
+            return
+        end
+
+        nb = 4
+        @cuda threads=(8*sizeof(T)+nb) kernel(T, a)
+        @test Array(a)[1] == ~zero(T) & ~((one(T) << nb) - one(T))
+        @test Array(a)[2] == ~zero(T) & ~((one(T) << nb) - one(T))
+    end
+end
+
+@testset "max" begin
+    @testset for T in [Int32, Int64, UInt32, UInt64]
+        a = CuTestArray([zero(T)])
+
+        function kernel(T, a)
+            i = threadIdx().x
+            @atomic a[1] = max(a[1], T(i))
+            return
+        end
+
+        @cuda threads=32 kernel(T, a)
+        @test Array(a)[1] == 32
+    end
+end
+
+@testset "min" begin
+    @testset for T in [Int32, Int64, UInt32, UInt64]
+        a = CuTestArray([typemax(T)])
+
+        function kernel(T, a)
+            i = threadIdx().x
+            @atomic a[1] = min(a[1], T(i))
+            return
+        end
+
+        @cuda threads=32 kernel(T, a)
+        @test Array(a)[1] == 1
     end
 end
 


### PR DESCRIPTION
Still needs test, integration with CuDeviceArray (do we need an Atomic type like Base?), API matching with Base and CUDA, etc.

```julia
julia> using CUDAnative: DevicePtr

julia> code_llvm(CUDAnative.atomic_inc!, (DevicePtr{Int32,AS.Shared}, Int32))

define i32 @"julia_atomic_inc!_12382"(i64, i32) {
top:
  %2 = call i32 @llvm.nvvm.atomic.load.inc.32.p3i32(i64 %0, i32 %1)
  ret i32 %2
}

julia> code_llvm(CUDAnative.atomic_max!, (DevicePtr{UInt,AS.Generic}, UInt))

define i64 @"julia_atomic_max!_12417"(i64, i64) {
top:
    %2 = inttoptr i64 %0 to i64*
    %3 = atomicrmw umax i64* %2, i64 %1 acq_rel
  ret i64 %3
}

julia> code_llvm(CUDAnative.atomic_add!, (DevicePtr{Int,AS.Generic}, Int))

define i64 @"julia_atomic_add!_12456"(i64, i64) {
top:
    %2 = inttoptr i64 %0 to i64*
    %3 = atomicrmw add i64* %2, i64 %1 acq_rel
  ret i64 %3
}
```