### PR TITLE
Support for resetting the device.

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,6 +42,8 @@ if CUDAnative.configured
             nothing
         end
 
+        device_reset!()
+
         # test the device selection functionality
         if length(devices()) > 1
             device!(1) do


### PR DESCRIPTION
~TODO: make the compilecache `device => ...` (we only really support a single context in CUDAnative) and wipe that.~