### PR TITLE
WIP: Generalise Grid Synchronisation to Multi-Grid/Multi-Device

### DIFF
--- a/src/device/cuda/cooperative_groups.jl
+++ b/src/device/cuda/cooperative_groups.jl
@@ -1,6 +1,26 @@
 # C. Cooperative Groups
 
-export this_grid, sync_grid
+export this_grid, sync_grid,
+       this_multi_grid, sync_multi_grid
+
+@enum cudaCGScope::Cuint begin
+     CGScopeInvalid   = 0  # Invalid cooperative group scope
+     CGScopeGrid           # Scope represented by a grid_group
+     CGScopeMultiGrid      # Scope represented by a multi_grid_group
+end
+
+
+# Intrinsic to get a handle for both grid groups and multi-grid groups:
+if VERSION >= v"1.2.0-DEV.512"
+    @inline cg_intrinsic_handle(cooperative_scope::cudaCGScope) =
+        ccall("extern cudaCGGetIntrinsicHandle", llvmcall, Culonglong, (cudaCGScope,), cooperative_scope)
+else
+    @eval @inline cg_intrinsic_handle(cooperative_scope::cudaCGScope) = Base.llvmcall(
+        $("declare i64 @cudaCGGetIntrinsicHandle(i32)",
+          "%rv = call i64 @cudaCGGetIntrinsicHandle(i32 %0)
+           ret i64 %rv"), Culonglong,
+        Tuple{cudaCGScope}, cooperative_scope)
+end
 
 """
     this_grid()
@@ -8,17 +28,28 @@ export this_grid, sync_grid
 Returns a `grid_handle` of the grid group this thread belongs to. Only available if a
 cooperative kernel is launched.
 """
-this_grid
+this_grid() = cg_intrinsic_handle(CGScopeGrid)
 
+"""
+    this_multi_grid()
+
+Returns a `multi_grid_handle` of the multi-grid group this thread belongs to. Only available
+if a cooperative kernel is launched.
+"""
+this_multi_grid() = cg_intrinsic_handle(CGScopeMultiGrid)
+
+
+# Intrinsic to synchronise both grid groups and multi-grid groups:
 if VERSION >= v"1.2.0-DEV.512"
-    @inline this_grid() =
-        ccall("extern cudaCGGetIntrinsicHandle", llvmcall, Culonglong, (Cuint,), UInt32(1))
+    @inline cg_sync_handle(grid_handle::Culonglong) =
+        ccall("extern cudaCGSynchronize", llvmcall, cudaError_t,
+              (Culonglong, Cuint), grid_handle, UInt32(0))
 else
-    @eval @inline this_grid() = Base.llvmcall(
-        $("declare i64 @cudaCGGetIntrinsicHandle(i32)",
-          "%rv = call i64 @cudaCGGetIntrinsicHandle(i32 1)
-           ret i64 %rv"), Culonglong,
-        Tuple{})
+    @eval @inline cg_sync_handle(grid_handle::Culonglong) = Base.llvmcall(
+        $("declare i32 @cudaCGSynchronize(i64, i32)",
+          "%rv = call i32 @cudaCGSynchronize(i64 %0, i32 0)
+           ret i32 %rv"), cudaError_t,
+        Tuple{Culonglong}, grid_handle)
 end
 
 """
@@ -28,16 +59,13 @@ Waits until all threads in all blocks in the grid `grid_handle` have reached thi
 all global memory accesses made by these threads prior to `sync_grid()` are visible to all
 threads in the grid. A 32-bit integer `cudaError_t` is returned.
 """
-sync_grid
+sync_grid(grid_handle::Culonglong) = cg_sync_handle(grid_handle)
 
-if VERSION >= v"1.2.0-DEV.512"
-    @inline sync_grid(grid_handle::Culonglong) =
-        ccall("extern cudaCGSynchronize", llvmcall, cudaError_t,
-              (Culonglong, Cuint), grid_handle, UInt32(0))
-else
-    @eval @inline sync_grid(grid_handle::Culonglong) = Base.llvmcall(
-        $("declare i32 @cudaCGSynchronize(i64, i32)",
-         "%rv = call i32 @cudaCGSynchronize(i64 %0, i32 0)
-           ret i32 %rv"), cudaError_t,
-        Tuple{Culonglong}, grid_handle)
-end
+"""
+    sync_multi_grid(multi_grid_handle::Culonglong)
+
+Waits until all threads in all blocks in the multi-grid `multi_grid_handle` have reached this
+point and all global memory accesses made by these threads prior to `sync_multi_grid()` are
+visible to all threads in the grid. A 32-bit integer `cudaError_t` is returned.
+"""
+sync_multi_grid(multi_grid_handle::Culonglong) = cg_sync_handle(multi_grid_handle)


### PR DESCRIPTION
Extracted `_get_handle()` and `_sync_handle()` for both grid group and multi-grid group. Also, added `cudaCGScope` to the same file as it is only used here. However, this cannot be used without a `cuLaunchCooperativeKernelMultiDevice()` CUDA API that will allow a single host thread to launch a kernel across multiple devices. This should be added to CUDAdrv.jl.

- [ ]  Add multi-device cooperative kernel launch to CUDAdrv
- [x]  Add `this_multi_grid()` and `sync_multi_grid()` to CUDAnative
- [ ]  Add tests for multi-device to CUDAnative

(Grid synchronisation was done in [Cooperative Kernel Launch #134](https://github.com/JuliaGPU/CUDAdrv.jl/pull/134) and [Grid Synchronization with Cooperative Groups #372](https://github.com/JuliaGPU/CUDAnative.jl/pull/372))