### PR TITLE
llvmcall tuple arguments need to be a literal.

### DIFF
--- a/src/device/cuda/cooperative_groups.jl
+++ b/src/device/cuda/cooperative_groups.jl
@@ -5,17 +5,18 @@ export this_grid, sync_grid
 """
     this_grid()
 
-Returns a `grid_handle` of the grid group this thread belongs to. Only available if a cooperative
-kernel is launched.
+Returns a `grid_handle` of the grid group this thread belongs to. Only available if a
+cooperative kernel is launched.
 """
 this_grid
 
 if VERSION >= v"1.2.0-DEV.512"
-    @inline this_grid() = ccall("extern cudaCGGetIntrinsicHandle", llvmcall, Culonglong, (Cuint,), UInt32(1))
+    @inline this_grid() =
+        ccall("extern cudaCGGetIntrinsicHandle", llvmcall, Culonglong, (Cuint,), UInt32(1))
 else
     @eval @inline this_grid() = Base.llvmcall(
-        ( "declare i64 @cudaCGGetIntrinsicHandle(i32)",
-         $"%rv = call i64 @cudaCGGetIntrinsicHandle(i32 1)
+        $("declare i64 @cudaCGGetIntrinsicHandle(i32)",
+          "%rv = call i64 @cudaCGGetIntrinsicHandle(i32 1)
            ret i64 %rv"), Culonglong,
         Tuple{})
 end
@@ -23,9 +24,9 @@ end
 """
     sync_grid(grid_handle::Culonglong)
 
-Waits until all threads in all blocks in the grid `grid_handle` have reached this point and all
-global memory accesses made by these threads prior to `sync_grid()` are visible to all threads
-in the grid. A 32-bit integer `cudaError_t` is returned.
+Waits until all threads in all blocks in the grid `grid_handle` have reached this point and
+all global memory accesses made by these threads prior to `sync_grid()` are visible to all
+threads in the grid. A 32-bit integer `cudaError_t` is returned.
 """
 sync_grid
 
@@ -35,8 +36,8 @@ if VERSION >= v"1.2.0-DEV.512"
               (Culonglong, Cuint), grid_handle, UInt32(0))
 else
     @eval @inline sync_grid(grid_handle::Culonglong) = Base.llvmcall(
-        ( "declare i32 @cudaCGSynchronize(i64, i32)",
-         $"%rv = call i32 @cudaCGSynchronize(i64 %0, i32 0)
+        $("declare i32 @cudaCGSynchronize(i64, i32)",
+         "%rv = call i32 @cudaCGSynchronize(i64 %0, i32 0)
            ret i32 %rv"), cudaError_t,
         Tuple{Culonglong}, grid_handle)
 end

--- a/src/device/cuda/dynamic_parallelism.jl
+++ b/src/device/cuda/dynamic_parallelism.jl
@@ -13,8 +13,8 @@ else
     # declare i32 @cudaLaunchDeviceV2(i8*, %struct.CUstream_st*)
     @eval @inline cudaLaunchDevice(buf::Ptr{Cvoid}, stream::CuStream) =
             Base.llvmcall(
-                ( "declare i32 @cudaLaunchDeviceV2(i8*, i8*)",
-                 $"%buf = inttoptr i$WORD_SIZE %0 to i8*
+                $("declare i32 @cudaLaunchDeviceV2(i8*, i8*)",
+                  "%buf = inttoptr i$WORD_SIZE %0 to i8*
                    %stream = inttoptr i$WORD_SIZE %1 to i8*
                    %rv = call i32 @cudaLaunchDeviceV2(i8* %buf, i8* %stream)
                    ret i32 %rv"), cudaError_t,
@@ -52,8 +52,8 @@ else
                                          threads_x::Cuint, threads_y::Cuint, threads_z::Cuint,
                                          shmem::Cuint) =
             Base.llvmcall(
-                ( "declare i8* @cudaGetParameterBufferV2(i8*, {i32,i32,i32}, {i32,i32,i32}, i32)",
-                 $"%f = inttoptr i$WORD_SIZE %0 to i8*
+                $("declare i8* @cudaGetParameterBufferV2(i8*, {i32,i32,i32}, {i32,i32,i32}, i32)",
+                  "%f = inttoptr i$WORD_SIZE %0 to i8*
                    %blocks.x = insertvalue { i32, i32, i32 } undef, i32 %1, 0
                    %blocks.y = insertvalue { i32, i32, i32 } %blocks.x, i32 %2, 1
                    %blocks.z = insertvalue { i32, i32, i32 } %blocks.y, i32 %3, 2
@@ -98,11 +98,10 @@ end
 if VERSION >= v"1.2.0-DEV.512"
     @inline synchronize() = ccall("extern cudaDeviceSynchronize", llvmcall, Cint, ())
 else
-    @eval @inline synchronize() =
-            Base.llvmcall(
-                ("declare i32 @cudaDeviceSynchronize()",
-                 "%rv = call i32 @cudaDeviceSynchronize()
-                  ret i32 %rv"), cudaError_t, Tuple{})
+    @eval @inline synchronize() = Base.llvmcall(
+        $("declare i32 @cudaDeviceSynchronize()",
+          "%rv = call i32 @cudaDeviceSynchronize()
+           ret i32 %rv"), cudaError_t, Tuple{})
 end
 
 """

--- a/src/execution.jl
+++ b/src/execution.jl
@@ -456,11 +456,10 @@ if VERSION >= v"1.2.0-DEV.512"
         ccall("extern cudanativeCompileKernel", llvmcall, Ptr{Cvoid}, (Int,), id)
 else
     import Base.Sys: WORD_SIZE
-    @eval @inline cudanativeCompileKernel(id::Int) =
-        Base.llvmcall(
-            ($"declare i$WORD_SIZE @cudanativeCompileKernel(i$WORD_SIZE)",
-             $"%rv = call i$WORD_SIZE @cudanativeCompileKernel(i$WORD_SIZE %0)
-               ret i$WORD_SIZE %rv"), Ptr{Cvoid}, Tuple{Int}, id)
+    @eval @inline cudanativeCompileKernel(id::Int) = Base.llvmcall(
+        $("declare i$WORD_SIZE @cudanativeCompileKernel(i$WORD_SIZE)",
+          "%rv = call i$WORD_SIZE @cudanativeCompileKernel(i$WORD_SIZE %0)
+           ret i$WORD_SIZE %rv"), Ptr{Cvoid}, Tuple{Int}, id)
 end
 
 const delayed_cufunctions = Vector{Tuple{Core.Function,Type}}()


### PR DESCRIPTION
Avoid construction at run-time; fixes #376.