### PR TITLE
Better errors for delayed bindings and dynamic calls

### DIFF
--- a/test/codegen.jl
+++ b/test/codegen.jl
@@ -557,6 +557,18 @@ end
     end
 end
 
+@testset "delayed bindings" begin
+    kernel() = (undefined; return)
+
+    @test_throws_message(CUDAnative.InvalidIRError,
+                         CUDAnative.codegen(:ptx, CUDAnative.CompilerJob(kernel, Tuple{}, cap, true))) do msg
+        occursin("invalid LLVM IR", msg) &&
+        occursin(CUDAnative.DELAYED_BINDING, msg) &&
+        occursin("use of 'undefined'", msg) &&
+        occursin(r"\[1\] .+kernel", msg)
+    end
+end
+
 end
 
 

--- a/test/codegen.jl
+++ b/test/codegen.jl
@@ -561,7 +561,7 @@ end
     kernel() = (undefined; return)
 
     @test_throws_message(CUDAnative.InvalidIRError,
-                         CUDAnative.codegen(:ptx, CUDAnative.CompilerJob(kernel, Tuple{}, cap, true))) do msg
+                         CUDAnative.code_llvm(kernel, Tuple{}; strict=true)) do msg
         occursin("invalid LLVM IR", msg) &&
         occursin(CUDAnative.DELAYED_BINDING, msg) &&
         occursin("use of 'undefined'", msg) &&
@@ -574,7 +574,7 @@ end
     kernel(a, b) = (unsafe_store!(b, nospecialize_child(a)); return)
 
     @test_throws_message(CUDAnative.InvalidIRError,
-                         CUDAnative.codegen(:ptx, CUDAnative.CompilerJob(kernel, Tuple{Int,Ptr{Int}}, cap, true))) do msg
+                         CUDAnative.code_llvm(kernel, Tuple{Int,Ptr{Int}}; strict=true)) do msg
         occursin("invalid LLVM IR", msg) &&
         occursin(CUDAnative.DYNAMIC_CALL, msg) &&
         occursin("call to nospecialize_child", msg) &&
@@ -586,7 +586,7 @@ end
     func() = pointer(1)
 
     @test_throws_message(CUDAnative.InvalidIRError,
-                         CUDAnative.codegen(:ptx, CUDAnative.CompilerJob(func, Tuple{}, cap, false))) do msg
+                         CUDAnative.code_llvm(func, Tuple{}; strict=true)) do msg
         occursin("invalid LLVM IR", msg) &&
         occursin(CUDAnative.DYNAMIC_CALL, msg) &&
         occursin("call to pointer", msg) &&


### PR DESCRIPTION
Fix https://github.com/JuliaGPU/CUDAnative.jl/issues/384
Fix https://github.com/JuliaGPU/CUDAnative.jl/issues/361

```julia
julia> @cuda kernel()
ERROR: InvalidIRError: compiling kernel() resulted in invalid LLVM IR
Reason: unsupported use of an undefined name (use of 'undefined')
Stacktrace:
 [1] kernel at REPL[64]:1

julia> kernel() = (BoundsError(1); return)
kernel (generic function with 3 methods)

julia> @cuda kernel()
ERROR: InvalidIRError: compiling kernel() resulted in invalid LLVM IR
Reason: unsupported dynamic function call (call to BoundsError(a) in Core at boot.jl:240)
Stacktrace:
 [1] kernel at REPL[66]:1
```
