### PR TITLE
Partially cached compilation

### DIFF
--- a/src/compiler/irgen.jl
+++ b/src/compiler/irgen.jl
@@ -60,7 +60,8 @@ function compile_method_instance(job::CompilerJob, method_instance::Core.MethodI
 
         # find the function that this module defines
         llvmfs = filter(llvmf -> !isdeclaration(llvmf) &&
-                                 startswith(LLVM.name(llvmf), "julia_"),
+                                 startswith(LLVM.name(llvmf), "julia_") &&
+                                 linkage(llvmf) == LLVM.API.LLVMExternalLinkage,
                         collect(functions(ir)))
         @compiler_assert length(llvmfs) == 1 job
         llvmf = first(llvmfs)


### PR DESCRIPTION
Tries to fix #383 by maintaining our own compilation cache. Doesn't enable recursion, but should prevent us from generating ridiculously large LLVM modules. Won't be necessary post https://github.com/JuliaLang/julia/pull/25984.

```julia
julia> using CUDAnative

julia> function kernel(a, b)
           a[1] = 2
           b[1] = 3
           nothing
       end
kernel (generic function with 1 method)

julia> CUDAnative.code_llvm(kernel, NTuple{2,CuDeviceArray{Int,1,AS.Global}}; dump_module=true)
```
```llvm
; ModuleID = 'kernel'
source_filename = "kernel"
target triple = "nvptx64-nvidia-cuda"

%printf_args = type { i64 }

@exception = private unnamed_addr constant [10 x i8] c"exception\00"
@0 = private unnamed_addr constant [108 x i8] c"ERROR: a %s was thrown during kernel execution.\0A       Run Julia on debug level 2 for device stack traces.\0A\00"

define void @julia_kernel_27({ [1 x i64], i64 } addrspace(11)* nocapture nonnull readonly dereferenceable(16), { [1 x i64], i64 } addrspace(11)* nocapture nonnull readonly dereferenceable(16)) local_unnamed_addr {
top:
  %2 = alloca [1 x i64], align 8
  %3 = alloca [1 x i64], align 8
  %4 = getelementptr inbounds [1 x i64], [1 x i64]* %2, i64 0, i64 0
  store i64 1, i64* %4, align 8, !tbaa !1
  %5 = getelementptr { [1 x i64], i64 }, { [1 x i64], i64 } addrspace(11)* %0, i64 0, i32 0, i64 0
  %6 = load i64, i64 addrspace(11)* %5, align 8, !tbaa !4, !invariant.load !6
  %7 = icmp slt i64 %6, 1
  br i1 %7, label %L12, label %L15

L12:                                              ; preds = %top
  %8 = addrspacecast [1 x i64]* %2 to [1 x i64] addrspace(11)*
  call fastcc void @julia_throw_boundserror_16482()
  call void asm sideeffect "trap;", ""() #1
  br label %L15

L15:                                              ; preds = %L12, %top
  %9 = getelementptr inbounds { [1 x i64], i64 }, { [1 x i64], i64 } addrspace(11)* %0, i64 0, i32 1
  %10 = bitcast i64 addrspace(11)* %9 to i64* addrspace(11)*
  %11 = load i64*, i64* addrspace(11)* %10, align 8, !tbaa !4, !invariant.load !6
  %12 = addrspacecast i64* %11 to i64 addrspace(1)*
  store i64 2, i64 addrspace(1)* %12, align 8, !tbaa !7
  %13 = getelementptr inbounds [1 x i64], [1 x i64]* %3, i64 0, i64 0
  store i64 1, i64* %13, align 8, !tbaa !1
  %14 = getelementptr { [1 x i64], i64 }, { [1 x i64], i64 } addrspace(11)* %1, i64 0, i32 0, i64 0
  %15 = load i64, i64 addrspace(11)* %14, align 8, !tbaa !4, !invariant.load !6
  %16 = icmp slt i64 %15, 1
  br i1 %16, label %L31, label %L34

L31:                                              ; preds = %L15
  %17 = addrspacecast [1 x i64]* %3 to [1 x i64] addrspace(11)*
  call fastcc void @julia_throw_boundserror_16482()
  call void asm sideeffect "trap;", ""() #1
  br label %L34

L34:                                              ; preds = %L31, %L15
  %18 = getelementptr inbounds { [1 x i64], i64 }, { [1 x i64], i64 } addrspace(11)* %1, i64 0, i32 1
  %19 = bitcast i64 addrspace(11)* %18 to i64* addrspace(11)*
  %20 = load i64*, i64* addrspace(11)* %19, align 8, !tbaa !4, !invariant.load !6
  %21 = addrspacecast i64* %20 to i64 addrspace(1)*
  store i64 3, i64 addrspace(1)* %21, align 8, !tbaa !7
  ret void
}

define internal fastcc void @julia_throw_boundserror_16482() unnamed_addr {
top:
  call fastcc void @ptx_report_exception(i64 ptrtoint ([10 x i8]* @exception to i64))
  call void asm sideeffect "trap;", ""() #1
  ret void
}

define internal fastcc void @ptx_report_exception(i64) unnamed_addr {
top:
  %1 = alloca %printf_args, align 8
  %2 = bitcast %printf_args* %1 to i8*
  call void @llvm.lifetime.start.p0i8(i64 8, i8* %2)
  %3 = getelementptr inbounds %printf_args, %printf_args* %1, i64 0, i32 0
  store i64 %0, i64* %3, align 8
  %4 = call i32 @vprintf(i8* getelementptr inbounds ([108 x i8], [108 x i8]* @0, i64 0, i64 0), i8* %2)
  call void @llvm.lifetime.end.p0i8(i64 8, i8* %2)
  ret void
}

; Function Attrs: argmemonly nounwind
declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #0

declare i32 @vprintf(i8*, i8*) local_unnamed_addr

; Function Attrs: argmemonly nounwind
declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #0

attributes #0 = { argmemonly nounwind }
attributes #1 = { nounwind }

!llvm.module.flags = !{!0}

!0 = !{i32 1, !"Debug Info Version", i32 3}
!1 = !{!2, !2, i64 0}
!2 = !{!"jtbaa_stack", !3, i64 0}
!3 = !{!"jtbaa"}
!4 = !{!5, !5, i64 0, i64 1}
!5 = !{!"jtbaa_const", !3, i64 0}
!6 = !{}
!7 = !{!8, !8, i64 0, i64 0}
!8 = !{!"ptxtbaa_global", !9, i64 0}
!9 = !{!"ptxtbaa"}
```

Look ma, only one `@julia_throw_boundserror`!

Testing with https://github.com/JuliaGPU/CUDAnative.jl/issues/383:

```
 ────────────────────────────────────────────────────────────────────────────────────
                                             Time                   Allocations      
                                     ──────────────────────   ───────────────────────
          Tot / % measured:               30.1s / 40.2%           2.20GiB / 28.8%    

 Section                     ncalls     time   %tot     avg     alloc   %tot      avg
 ────────────────────────────────────────────────────────────────────────────────────
 LLVM middle-end                  1    7.37s  60.9%   7.37s    450MiB  69.1%   450MiB
   IR generation                  1    4.62s  38.2%   4.62s    422MiB  64.7%   422MiB
     emission                     1    3.01s  24.9%   3.01s    283MiB  43.4%   283MiB
     rewrite                      1    1.57s  13.0%   1.57s    139MiB  21.3%   139MiB
       lower throw                1    322ms  2.66%   322ms   35.6MiB  5.47%  35.6MiB
       hide unreachable          12    308ms  2.55%  25.7ms   20.3MiB  3.11%  1.69MiB
         predecessors            12    191ms  1.57%  15.9ms   8.91MiB  1.37%   760KiB
         find                    12    111ms  0.92%  9.27ms    606KiB  0.09%  50.5KiB
         replace                 12    290μs  0.00%  24.2μs   1.59KiB  0.00%     136B
       hide trap                  1   25.5ms  0.21%  25.5ms   1.89MiB  0.29%  1.89MiB
     linking                      1   31.5ms  0.26%  31.5ms   89.3KiB  0.01%  89.3KiB
     clean-up                     1    122μs  0.00%   122μs   5.63KiB  0.00%  5.63KiB
   optimization                   1    2.73s  22.6%   2.73s   28.3MiB  4.35%  28.3MiB
 CUDA object generation           1    2.11s  17.5%   2.11s   5.80MiB  0.89%  5.80MiB
   linking                        1    2.03s  16.8%   2.03s   1.00MiB  0.15%  1.00MiB
   compilation                    1   85.0ms  0.70%  85.0ms   4.80MiB  0.74%  4.80MiB
 validation                       2    1.94s  16.1%   972ms    191MiB  29.4%  95.7MiB
 LLVM back-end                    1    672ms  5.55%   672ms   3.62MiB  0.56%  3.62MiB
   machine-code generation        1    635ms  5.25%   635ms   1.27MiB  0.20%  1.27MiB
   preparation                    1   37.0ms  0.31%  37.0ms   2.35MiB  0.36%  2.35MiB
 Julia front-end                  1   6.63ms  0.05%  6.63ms    236KiB  0.04%   236KiB
 ────────────────────────────────────────────────────────────────────────────────────
```

cc @dpsanders @vchuravy (probably also interesting for Oceananigans/GPUifyLoops?)