### PR TITLE
default to debuginfo for typed code

### DIFF
--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -213,7 +213,7 @@ macro device_code_typed(ex...)
     quote
         buf = Any[]
         function hook(job::CompilerJob)
-            append!(buf, code_typed(job.f, job.tt))
+            append!(buf, code_typed(job.f, job.tt, debuginfo=:source))
         end
         $(emit_hooked_compilation(:hook, ex...))
         buf
@@ -291,7 +291,7 @@ macro device_code(ex...)
         end
 
         open(joinpath(dir, "$fn.typed.jl"), "w") do io
-            code = only(code_typed(job.f, job.tt))
+            code = only(code_typed(job.f, job.tt, debuginfo=:source))
             println(io, code)
         end
 


### PR DESCRIPTION
Makes `@device_code_typed` slightly more useful since now one can relate
back quirks to actual line information