### PR TITLE
relax ABI check

### DIFF
--- a/src/compiler/common.jl
+++ b/src/compiler/common.jl
@@ -82,7 +82,7 @@ function Base.showerror(io::IO, err::InternalCompilerError)
     let Pkg = Base.require(Base.PkgId(Base.UUID((0x44cfe95a1eb252ea, 0xb672e2afdf69b78f)), "Pkg"))
         println(io, "\nInstalled packages:")
         for (pkg,ver) in Pkg.installed()
-            println(io, " - $pkg = $ver")
+            println(io, " - $pkg = $(repr(ver))")
         end
     end
 

--- a/src/compiler/irgen.jl
+++ b/src/compiler/irgen.jl
@@ -78,12 +78,6 @@ function compile_method_instance(job::CompilerJob, method_instance::Core.MethodI
         insert!(dependencies, last_method_instance, llvmf)
     end
     function hook_emit_function(method_instance, code, world)
-        skip_verifier = false
-        if length(call_stack) >= 1
-            caller = last(call_stack)
-            skip_verifier = caller.def.name === :overdub
-        end
-
         push!(call_stack, method_instance)
 
         # check for recursion
@@ -91,9 +85,6 @@ function compile_method_instance(job::CompilerJob, method_instance::Core.MethodI
             throw(KernelError(job, "recursion is currently not supported";
                               bt=backtrace(job, call_stack)))
         end
-
-        # if last method on stack is overdub skip the Base check and trust in Cassette
-        skip_verifier && return
 
         # check for Base functions that exist in CUDAnative too
         # FIXME: this might be too coarse

--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -213,7 +213,11 @@ macro device_code_typed(ex...)
     quote
         buf = Any[]
         function hook(job::CompilerJob)
-            append!(buf, code_typed(job.f, job.tt, debuginfo=:source))
+            if VERSION >= v"1.1.0"
+                append!(buf, code_typed(job.f, job.tt, debuginfo=:source))
+            else
+                append!(buf, code_typed(job.f, job.tt))
+            end
         end
         $(emit_hooked_compilation(:hook, ex...))
         buf
@@ -292,7 +296,11 @@ macro device_code(ex...)
         end
 
         open(joinpath(dir, "$fn.typed.jl"), "w") do io
-            code = only(code_typed(job.f, job.tt, debuginfo=:source))
+            if VERSION >= v"1.1.0"
+                code = only(code_typed(job.f, job.tt, debuginfo=:source))
+            else
+                code = only(code_typed(job.f, job.tt))
+            end
             println(io, code)
         end
 

--- a/test/codegen.jl
+++ b/test/codegen.jl
@@ -477,17 +477,6 @@ end
     @test occursin(r"\[2\] .+foobar", bt_msg)
 end
 
-@testset "do not verify hack for base intrinsics" begin
-    @noinline overdub(f::F, args...) where F = f(args...)
-    foobar(i) = overdub(sin, i)
-
-    # NOTE: we don't use test_logs in order to test all of the warning (exception, backtrace)
-    logs, _ = Test.collect_test_logs() do
-        CUDAnative.code_llvm(devnull, foobar, Tuple{Int})
-    end
-    @test length(logs) == 0
-end
-
 # some validation happens in `compile`
 
 @eval Main begin

--- a/test/device/execution.jl
+++ b/test/device/execution.jl
@@ -70,6 +70,12 @@ end
         @test occursin("Body::Union{}", err)
     end
 
+    let
+        range_kernel() = (0.0:0.1:100.0; nothing)
+
+        @test_throws CUDAnative.InvalidIRError @cuda range_kernel()
+    end
+
     # set name of kernel
     @test occursin("ptxcall_mykernel", sprint(io->(@device_code_llvm io=io begin
         k = cufunction(dummy, name="mykernel")


### PR DESCRIPTION
attempt at fixing #412 the example now leads to:

```
┌ Warning: Possible ABI missmatch                                                                                                                                                                                                     
│   name = "japi1_print_to_string_16521"                                                                                                                                                                                              
└ @ CUDAnative ~/.julia/dev/CUDAnative/src/compiler/irgen.jl:70                                                                                                                                                                       
┌ Warning: Possible ABI missmatch                                                                                                                                                                                                     
│   name = "japi1_print_to_string_16545"                                                                                                                                                                                              
└ @ CUDAnative ~/.julia/dev/CUDAnative/src/compiler/irgen.jl:70                                                                                                                                                                       
┌ Warning: Possible ABI missmatch                                                                                                                                                                                                     
│   name = "japi1_print_to_string_16555"                                                                                                                                                                                              
└ @ CUDAnative ~/.julia/dev/CUDAnative/src/compiler/irgen.jl:70                                                                                                                                                                       
┌ Warning: Possible ABI missmatch                                                                                                                                                                                                     
│   name = "japi1_print_to_string_16567"                                                                                                                                                                                              
└ @ CUDAnative ~/.julia/dev/CUDAnative/src/compiler/irgen.jl:70                                                                                                                                                                       
┌ Warning: Possible ABI missmatch                                                                                                                                                                                                     
│   name = "japi1_print_to_string_16577"                                                                                                                                                                                              
└ @ CUDAnative ~/.julia/dev/CUDAnative/src/compiler/irgen.jl:70                                                                                                                                                                       
┌ Warning: Possible ABI missmatch                                                                                                                                                                                                     
│   name = "japi1_print_to_string_16587"                                                                                                                                                                                              
└ @ CUDAnative ~/.julia/dev/CUDAnative/src/compiler/irgen.jl:70                                                                                                                                                                       
┌ Warning: Possible ABI missmatch                                                                                                                                                                                                     
│   name = "japi1_print_to_string_16597"                                                                                                                                                                                              
└ @ CUDAnative ~/.julia/dev/CUDAnative/src/compiler/irgen.jl:70     
ERROR: LoadError: InvalidIRError: compiling ff() resulted in invalid LLVM IR                                                                                                                                                          
Reason: unsupported call to the Julia runtime (call to jl_f_tuple)                                                                                                                                                                    
Stacktrace:                                                                                                                                                                                                                           
 [1] log2 at math.jl:486                                                                                                                                                                                                              
 [2] log2 at math.jl:488                                                                                                                                                                                                              
 [3] nbitslen at twiceprecision.jl:234                                                                                                                                                                                                
 [4] nbitslen at twiceprecision.jl:230                                                                                                                                                                                                
 [5] floatrange at twiceprecision.jl:367                                                                                                                                                                                              
 [6] Colon at twiceprecision.jl:407                                                                                                                                                                                                   
 [7] ff at /home/vchuravy/test.jl:4                                                                                                                                                                                                   
Reason: unsupported call to the Julia runtime (call to jl_type_error)                                                                                                                                                                 
Stacktrace:                                                                                                                                                                                                                           
 [1] log2 at math.jl:486                                                                                                                                                                                                              
 [2] log2 at math.jl:488                                                                                                                                                                                                              
 [3] nbitslen at twiceprecision.jl:234                                                                                                                                                                                                
 [4] nbitslen at twiceprecision.jl:230                                                                                                                                                                                                
 [5] floatrange at twiceprecision.jl:367                                                                                                                                                                                              
 [6] Colon at twiceprecision.jl:407                                                                                                                                                                                                   
 [7] ff at /home/vchuravy/test.jl:4                                                                                                                                                                                                   
Reason: unsupported dynamic function invocation (call to __throw_gcd_overflow(a, b) in Base at intfuncs.jl:50)                                                                                                                        
Stacktrace:                                                                                                                                                                                                                           
 [1] gcd at intfuncs.jl:47                                                                                                                                                                                                            
 [2] lcm at intfuncs.jl:71                                                                                                                                                                                                            
 [3] Colon at twiceprecision.jl:396                                                                                                                                                                                                   
 [4] ff at /home/vchuravy/test.jl:4                                                                                                                                                                                                   
Reason: unsupported call through a literal pointer (call to jl_alloc_string)                                                                                                                                                          
Stacktrace:                                                                                                                                                                                                                           
 [1] _string_n at strings/string.jl:60                                                                                                                                                                                                
 [2] StringVector at iobuffer.jl:31                                                                                                                                                                                                   
 [3] #IOBuffer#320 at iobuffer.jl:114                                                                                                                                                                                                 
 [4] Type at none:0                                                                                                                                                                                                                   
 [5] print_to_string at strings/io.jl:127                                                                                                                                                                                             
 [6] multiple call sites at unknown:0                                                                                                                                                                                                 
Reason: unsupported call through a literal pointer (call to jl_string_to_array)                                                                                                                                                       
Stacktrace:                                                                                                                                                                                                                           
 [1] unsafe_wrap at strings/string.jl:71                                                                                                                                                                                              
 [2] StringVector at iobuffer.jl:31                                                                                                                                                                                                   
 [3] #IOBuffer#320 at iobuffer.jl:114                                                                                                                                                                                                 
 [4] Type at none:0                                                                                                                                                                                                                   
 [5] print_to_string at strings/io.jl:127                                                                                                                                                                                             
 [6] multiple call sites at unknown:0                                                                                                                                                                                                 
Reason: unsupported call through a literal pointer (call to )                                                                                                                                                                         
Stacktrace:                                                                                                                                                                                                                           
 [1] fill! at array.jl:366                                                                                                                                                                                                            
 [2] #IOBuffer#320 at iobuffer.jl:121                                                                                                                                                                                                 
 [3] Type at none:0                                                                                                                                                                                                                   
 [4] print_to_string at strings/io.jl:127                                                                                                                                                                                             
 [5] multiple call sites at unknown:0          
Reason: unsupported dynamic function invocation (call to tostr_sizehint)
Stacktrace:
 [1] print_to_string at strings/io.jl:124
 [2] multiple call sites at unknown:0
Reason: unsupported dynamic function invocation (call to +)
Stacktrace:
 [1] print_to_string at strings/io.jl:124
 [2] multiple call sites at unknown:0
Reason: unsupported dynamic function invocation (call to convert)
Stacktrace:
 [1] print_to_string at strings/io.jl:124
 [2] multiple call sites at unknown:0
Reason: unsupported dynamic function invocation (call to print)
Stacktrace:
 [1] print_to_string at strings/io.jl:129
 [2] multiple call sites at unknown:0
Reason: unsupported call through a literal pointer (call to jl_array_grow_end)
Stacktrace:
 [1] _growend! at array.jl:811
 [2] resize! at array.jl:1003
 [3] print_to_string at strings/io.jl:131
 [4] multiple call sites at unknown:0
Reason: unsupported call through a literal pointer (call to jl_array_del_end)
Stacktrace:
 [1] _deleteend! at array.jl:820
 [2] resize! at array.jl:1008
 [3] print_to_string at strings/io.jl:131
 [4] multiple call sites at unknown:0Reason: unsupported call through a literal pointer (call to jl_array_to_string)
Stacktrace:
 [1] String at strings/string.jl:39
 [2] print_to_string at strings/io.jl:131
 [3] multiple call sites at unknown:0
Reason: unsupported call to the Julia runtime (call to jl_type_error)
Stacktrace:
 [1] print_to_string at strings/io.jl:124
 [2] multiple call sites at unknown:0
Stacktrace:
 [1] check_ir(::CUDAnative.CompilerJob, ::LLVM.Module) at /home/vchuravy/.julia/dev/CUDAnative/src/compiler/validation.jl:114                                                                                                        
 [2] macro expansion at /home/vchuravy/.julia/packages/TimerOutputs/7zSea/src/TimerOutput.jl:216 [inlined]
 [3] #codegen#119(::Bool, ::Bool, ::Bool, ::Bool, ::Bool, ::typeof(CUDAnative.codegen), ::Symbol, ::CUDAnative.CompilerJob) at /home/vchuravy/.julia/dev/CUDAnative/src/compiler/driver.jl:186                                       
 [4] #codegen at ./none:0 [inlined]
 [5] #compile#118(::Bool, ::Bool, ::Bool, ::Bool, ::Bool, ::typeof(CUDAnative.compile), ::Symbol, ::CUDAnative.CompilerJob) at /home/vchuravy/.julia/dev/CUDAnative/src/compiler/driver.jl:47                                        
 [6] #compile#117 at ./none:0 [inlined]
 [7] compile at /home/vchuravy/.julia/dev/CUDAnative/src/compiler/driver.jl:28 [inlined] (repeats 2 times)
 [8] macro expansion at /home/vchuravy/.julia/dev/CUDAnative/src/execution.jl:378 [inlined]
 [9] #cufunction#159(::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}, ::typeof(cufunction), ::typeof(ff), ::Type{Tuple{}}) at /home/vchuravy/.julia/dev/CUDAnative/src/execution.jl:347                       
 [10] cufunction(::Function, ::Type) at /home/vchuravy/.julia/dev/CUDAnative/src/execution.jl:347
 [11] top-level scope at /home/vchuravy/.julia/dev/CUDAnative/src/execution.jl:174
 [12] top-level scope at gcutils.jl:87
 [13] top-level scope at /home/vchuravy/.julia/dev/CUDAnative/src/execution.jl:171
 [14] include at ./boot.jl:328 [inlined]
 [15] include_relative(::Module, ::String) at ./loading.jl:1094
 [16] include(::Module, ::String) at ./Base.jl:31
 [17] exec_options(::Base.JLOptions) at ./client.jl:295
 [18] _start() at ./client.jl:464
in expression starting at /home/vchuravy/test.jl:9