### PR TITLE
Support custom allocators, implement a bump allocator

### DIFF
--- a/examples/bump-allocator.jl
+++ b/examples/bump-allocator.jl
@@ -1,0 +1,40 @@
+using Test
+
+using CUDAdrv, CUDAnative
+include(joinpath(@__DIR__, "..", "test", "array.jl"))   # real applications: use CuArrays.jl
+
+mutable struct Box{T}
+    value::T
+end
+
+function vcopy(a, b)
+    i = (blockIdx().x-1) * blockDim().x + threadIdx().x
+    box = Box(a[i])
+    b[i] = box.value
+    return
+end
+
+dims = (3,4)
+a = round.(rand(Float32, dims) * 100)
+b = similar(a)
+
+d_a = CuTestArray(a)
+d_b = CuTestArray(b)
+
+len = prod(dims)
+
+# Allocate a 1 MiB heap for the bump allocator.
+heap_capacity = 1024 * 1024
+heap = Mem.alloc(Mem.DeviceBuffer, heap_capacity)
+heap_start_address = pointer(heap)
+# Create an initialization callback for the bump allocator.
+function init(kernel)
+    CUDAnative.Runtime.bump_alloc_init!(kernel, heap_start_address, heap_capacity)
+end
+# Run the kernel.
+@cuda threads=len init=init malloc="ptx_bump_alloc" vcopy(d_a, d_b)
+# Free the heap.
+Mem.free(heap)
+
+b = Array(d_b)
+@test a ≈ b

--- a/src/compiler/common.jl
+++ b/src/compiler/common.jl
@@ -13,11 +13,17 @@ struct CompilerJob
     blocks_per_sm::Union{Nothing,Integer}
     maxregs::Union{Nothing,Integer}
     name::Union{Nothing,String}
+    # The name of the 'malloc' function to use when allocating memory.
+    # A transform will rewrite all calls to 'malloc' to use this function
+    # instead. The 'malloc' signature must be 'void* malloc(size_t)' or
+    # compatible.
+    malloc::String
 
     CompilerJob(f, tt, cap, kernel; name=nothing,
                     minthreads=nothing, maxthreads=nothing,
-                    blocks_per_sm=nothing, maxregs=nothing) =
-        new(f, tt, cap, kernel, minthreads, maxthreads, blocks_per_sm, maxregs, name)
+                    blocks_per_sm=nothing, maxregs=nothing,
+                    malloc="malloc") =
+        new(f, tt, cap, kernel, minthreads, maxthreads, blocks_per_sm, maxregs, name, malloc)
 end
 
 # global job reference

--- a/src/compiler/common.jl
+++ b/src/compiler/common.jl
@@ -13,10 +13,10 @@ struct CompilerJob
     blocks_per_sm::Union{Nothing,Integer}
     maxregs::Union{Nothing,Integer}
     name::Union{Nothing,String}
-    # The name of the 'malloc' function to use when allocating memory.
-    # A transform will rewrite all calls to 'malloc' to use this function
-    # instead. The 'malloc' signature must be 'void* malloc(size_t)' or
-    # compatible.
+    # The name of the memory allocation function to use when allocating
+    # managed memory. A transform will rewrite all managed memory allocations
+    # to use this function instead. The 'malloc' signature must be
+    # 'void* malloc(size_t)' or compatible.
     malloc::String
 
     CompilerJob(f, tt, cap, kernel; name=nothing,

--- a/src/compiler/driver.jl
+++ b/src/compiler/driver.jl
@@ -91,7 +91,7 @@ function codegen(target::Symbol, job::CompilerJob;
     # always preload the runtime, and do so early; it cannot be part of any timing block
     # because it recurses into the compiler
     if libraries
-        runtime = load_runtime(job.cap)
+        runtime = load_runtime(job.cap, job.malloc)
         runtime_fns = LLVM.name.(defs(runtime))
     end
 

--- a/src/compiler/optim.jl
+++ b/src/compiler/optim.jl
@@ -63,6 +63,7 @@ function optimize!(job::CompilerJob, mod::LLVM.Module, entry::LLVM.Function)
 
             run!(pm, mod)
         end
+        replace_malloc!(mod, job.malloc)
     end
 
     # PTX-specific optimizations
@@ -353,6 +354,46 @@ function lower_gc_frame!(fun::LLVM.Function)
     end
 
     return changed
+end
+
+# Replaces all uses of a function in a particular module with
+# a compatible function.
+function replace_function!(mod::LLVM.Module, old_name::String, new_name::String)
+    if new_name == old_name
+        # There's nothing to replace if the new function is the same as
+        # the old function.
+        return false
+    end
+
+    # Otherwise, we'll try and find the old function.
+    if !haskey(functions(mod), old_name)
+        # If the old function doesn't even appear in the module, then it's not in
+        # use and we can stop right here.
+        return false
+    end
+
+    old_function = functions(mod)[old_name]
+
+    if haskey(functions(mod), new_name)
+        new_function = functions(mod)[new_name]
+    else
+        # Create a new function.
+        new_function = LLVM.Function(
+            mod,
+            new_name,
+            eltype(llvmtype(old_function)::LLVM.PointerType)::LLVM.FunctionType)
+    end
+
+    # Replace all uses of the old function with the new function.
+    replace_uses!(old_function, new_function)
+
+    return true
+end
+
+# Replaces all uses of the managed memory allocation function in a
+# particular module with a compatible function with the specified name.
+function replace_malloc!(mod::LLVM.Module, malloc_name::String)
+    return replace_function!(mod, "julia.managed_malloc", malloc_name)
 end
 
 # lower the `julia.ptls_states` intrinsic by removing it, since it is GPU incompatible.

--- a/src/compiler/validation.jl
+++ b/src/compiler/validation.jl
@@ -231,7 +231,7 @@ function check_ir!(job, errors::Vector{IRError}, inst::LLVM.CallInst)
         end
 
         # detect calls to undefined functions
-        if isdeclaration(dest) && intrinsic_id(dest) == 0 && !(fn in special_fns)
+        if isdeclaration(dest) && intrinsic_id(dest) == 0 && !(fn in special_fns) && fn != job.malloc
             # figure out if the function lives in the Julia runtime library
             if libjulia[] == C_NULL
                 paths = filter(Libdl.dllist()) do path

--- a/src/device/runtime.jl
+++ b/src/device/runtime.jl
@@ -12,6 +12,7 @@ module Runtime
 using ..CUDAnative
 using LLVM
 using LLVM.Interop
+using CUDAdrv
 
 
 ## representation of a runtime method instance
@@ -249,6 +250,87 @@ for (T, t) in [Int8   => :int8,  Int16  => :int16,  Int32  => :int32,  Int64  =>
         compile($box_fn, Any, ($T,), T_prjlvalue; llvm_name=$"jl_$box_fn")
         compile($unbox_fn, $T, (Any,); llvm_name=$"jl_$unbox_fn")
     end
+end
+
+## Bump allocator.
+
+# Gets a pointer to a global with a particular name. If the global
+# does not exist yet, then it is declared in the global memory address
+# space.
+@generated function get_global_pointer(::Val{global_name}, ::Type{T})::Ptr{T} where {global_name, T}
+    T_global = convert(LLVMType, T)
+    T_result = convert(LLVMType, Ptr{T})
+
+    # Create a thunk that computes a pointer to the global.
+    llvm_f, _ = create_function(T_result)
+    mod = LLVM.parent(llvm_f)
+
+    # Figure out if the global has been defined already.
+    global_set = LLVM.globals(mod)
+    global_name_string = String(global_name)
+    if haskey(global_set, global_name_string)
+        global_var = global_set[global_name_string]
+    else
+        # If the global hasn't been defined already, then we'll define
+        # it in the global address space, i.e., address space one.
+        global_var = GlobalVariable(mod, T_global, global_name_string, 1)
+        linkage!(global_var, LLVM.API.LLVMLinkOnceODRLinkage)
+        initializer!(global_var, LLVM.null(T_global))
+    end
+
+    # Generate IR that computes the global's address.
+    Builder(JuliaContext()) do builder
+        entry = BasicBlock(llvm_f, "entry", JuliaContext())
+        position!(builder, entry)
+
+        # Cast the global variable's type to the result type.
+        result = ptrtoint!(builder, global_var, T_result)
+        ret!(builder, result)
+    end
+
+    # Call the function.
+    call_function(llvm_f, Ptr{T})
+end
+
+macro cuda_global_ptr(name, type)
+    return :(convert(
+        DevicePtr{T},
+        get_global_pointer(
+            $(Val(Symbol(name))),
+            $(esc(type)))))
+end
+
+# Allocates `bytesize` bytes of storage by bumping the global bump
+# allocator pointer.
+function bump_alloc(bytesize::Csize_t)::Ptr{UInt8}
+    ptr = @cuda_global_ptr("bump_alloc_ptr", Csize_t)
+    chunk_address = atomic_add!(ptr, bytesize)
+    end_ptr = unsafe_load(@cuda_global_ptr("bump_alloc_end", Csize_t))
+    if chunk_address < end_ptr
+        return convert(Ptr{UInt8}, chunk_address)
+    else
+        return C_NULL
+    end
+end
+
+compile(bump_alloc, Ptr{UInt8}, (Csize_t,))
+
+function maybe_set_global(kernel, name, value::T) where T
+    try
+        global_handle = CuGlobal{T}(kernel.mod, name)
+        set(global_handle, value)
+    catch exception
+        # The interrupt pointer may not have been declared (because it is unused).
+        # In that case, we should do nothing.
+        if !isa(exception, CUDAdrv.CuError) || exception.code != CUDAdrv.ERROR_NOT_FOUND.code
+            rethrow()
+        end
+    end
+end
+
+function bump_alloc_init!(kernel, buffer_start, buffer_size)
+    maybe_set_global(kernel, "bump_alloc_ptr", buffer_start)
+    maybe_set_global(kernel, "bump_alloc_end", buffer_start + buffer_size)
 end
 
 end

--- a/src/execution.jl
+++ b/src/execution.jl
@@ -9,7 +9,7 @@ export @cuda, cudaconvert, cufunction, dynamic_cufunction, nearest_warpsize
 # the code it generates, or the execution
 function split_kwargs(kwargs)
     macro_kws    = [:dynamic]
-    compiler_kws = [:minthreads, :maxthreads, :blocks_per_sm, :maxregs, :name]
+    compiler_kws = [:minthreads, :maxthreads, :blocks_per_sm, :maxregs, :name, :malloc]
     call_kws     = [:cooperative, :blocks, :threads, :config, :shmem, :stream]
     macro_kwargs = []
     compiler_kwargs = []

--- a/src/execution.jl
+++ b/src/execution.jl
@@ -8,7 +8,7 @@ export @cuda, cudaconvert, cufunction, dynamic_cufunction, nearest_warpsize
 # split keyword arguments to `@cuda` into ones affecting the macro itself, the compiler and
 # the code it generates, or the execution
 function split_kwargs(kwargs)
-    macro_kws    = [:dynamic]
+    macro_kws    = [:dynamic, :init]
     compiler_kws = [:minthreads, :maxthreads, :blocks_per_sm, :maxregs, :name, :malloc]
     call_kws     = [:cooperative, :blocks, :threads, :config, :shmem, :stream]
     macro_kwargs = []
@@ -137,13 +137,14 @@ macro cuda(ex...)
 
     # handle keyword arguments that influence the macro's behavior
     dynamic = false
+    env_kwargs = []
     for kwarg in macro_kwargs
         key,val = kwarg.args
         if key == :dynamic
             isa(val, Bool) || throw(ArgumentError("`dynamic` keyword argument to @cuda should be a constant value"))
             dynamic = val::Bool
         else
-            throw(ArgumentError("Unsupported keyword argument '$key'"))
+            push!(env_kwargs, kwarg)
         end
     end
 
@@ -159,6 +160,7 @@ macro cuda(ex...)
                 # we're in kernel land already, so no need to cudaconvert arguments
                 local kernel_tt = Tuple{$((:(Core.Typeof($var)) for var in var_exprs)...)}
                 local kernel = dynamic_cufunction($(esc(f)), kernel_tt)
+                prepare_kernel(kernel; $(map(esc, env_kwargs)...))
                 kernel($(var_exprs...); $(map(esc, call_kwargs)...))
              end)
     else
@@ -173,6 +175,7 @@ macro cuda(ex...)
                     local kernel_tt = Tuple{Core.Typeof.(kernel_args)...}
                     local kernel = cufunction($(esc(f)), kernel_tt;
                                               $(map(esc, compiler_kwargs)...))
+                    prepare_kernel(kernel; $(map(esc, env_kwargs)...))
                     kernel(kernel_args...; $(map(esc, call_kwargs)...))
                 end
              end)
@@ -447,9 +450,25 @@ end
     return ex
 end
 
+"""
+    prepare_kernel(kernel::AbstractKernel{F,TT}; init::Function=nop_init_kernel)
+
+Prepares a kernel for execution by setting up an environment for that kernel.
+This function should be invoked just prior to running the kernel. Its
+functionality is included in [`@cuda`](@ref).
+
+The 'init' keyword argument is a function that takes a kernel as argument and
+sets up an environment for the kernel.
+"""
+function prepare_kernel(kernel::AbstractKernel{F,TT}; init::Function=nop_init_kernel) where {F,TT}
+    # Just call the 'init' function for now.
+    init(kernel)
+end
 
 ## device-side API
 
+# There doesn't seem to be a way to access the documentation for the call-syntax,
+# so attach it to the type
 """
     dynamic_cufunction(f, tt=Tuple{})
 
@@ -502,4 +521,9 @@ This is a common requirement, eg. when using shuffle intrinsics.
 function nearest_warpsize(dev::CuDevice, threads::Integer)
     ws = CUDAdrv.warpsize(dev)
     return threads + (ws - threads % ws) % ws
+end
+
+function nop_init_kernel(kernel::AbstractKernel{F,TT}) where {F,TT}
+    # Do nothing.
+    return
 end


### PR DESCRIPTION
This PR allows `@cuda` callers to pick a custom allocation function and implements a bump allocator, as per your request, @maleadt, in #419. I also threw in an example program that doubles as a test.