### PR TITLE
Use the new cgparam for LLVM 8.0 compatibility.

### DIFF
--- a/src/CUDAnative.jl
+++ b/src/CUDAnative.jl
@@ -20,6 +20,11 @@ verlist(vers) = join(map(ver->"$(ver.major).$(ver.minor)", sort(collect(vers))),
 function llvm_support(version)
     @debug("Using LLVM v$version")
 
+    # https://github.com/JuliaGPU/CUDAnative.jl/issues/428
+    if version >= v"8.0" && VERSION < v"1.3.0-DEV.547"
+        error("LLVM 8.0 requires a newer version of Julia")
+    end
+
     InitializeAllTargets()
     haskey(targets(), "nvptx") ||
         error("""

--- a/src/compiler/irgen.jl
+++ b/src/compiler/irgen.jl
@@ -113,15 +113,19 @@ function compile_method_instance(job::CompilerJob, method_instance::Core.MethodI
         @compiler_assert last(call_stack) == method job
         last_method_instance = pop!(call_stack)
     end
-    params = Base.CodegenParams(cached             = false,
-                                track_allocations  = false,
-                                code_coverage      = false,
-                                static_alloc       = false,
-                                prefer_specsig     = true,
-                                module_setup       = hook_module_setup,
-                                module_activation  = hook_module_activation,
-                                emit_function      = hook_emit_function,
-                                emitted_function   = hook_emitted_function)
+    param_kwargs = [:cached             => false,
+                    :track_allocations  => false,
+                    :code_coverage      => false,
+                    :static_alloc       => false,
+                    :prefer_specsig     => true,
+                    :module_setup       => hook_module_setup,
+                    :module_activation  => hook_module_activation,
+                    :emit_function      => hook_emit_function,
+                    :emitted_function   => hook_emitted_function]
+    if LLVM.version() >= v"8.0" && VERSION >= v"1.3.0-DEV.547"
+        push!(param_kwargs, :gnu_pubnames => false)
+    end
+    params = Base.CodegenParams(;param_kwargs...)
 
     # get the code
     ref = ccall(:jl_get_llvmf_defn, LLVM.API.LLVMValueRef,


### PR DESCRIPTION
Fixes #428, builds on https://github.com/JuliaLang/julia/pull/32518

@vchuravy do we need the other cgparam as well?