### PR TITLE
Escape $ in docstrings

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,3 +1,7 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[compat]
+Documenter = "~0.22.6"
+

--- a/src/device/cuda/output.jl
+++ b/src/device/cuda/output.jl
@@ -19,9 +19,9 @@ export @cuprintf
 end
 
 """
-Print a formatted string in device context on the host standard output:
-
     @cuprintf("%Fmt", args...)
+
+Print a formatted string in device context on the host standard output.
 
 Note that this is not a fully C-compliant `printf` implementation; see the CUDA
 documentation for supported options and inputs.
@@ -167,9 +167,10 @@ pointers. For more complex output, use `@cuprintf` directly.
 
 Limited string interpolation is also possible:
 
+```julia
     @cuprint("Hello, World ", 42, "\n")
     @cuprint "Hello, World \$(42)\n"
-
+```
 """
 macro cuprint(parts...)
     args = Union{Val,Expr,Symbol}[]

--- a/src/device/cuda/output.jl
+++ b/src/device/cuda/output.jl
@@ -168,7 +168,7 @@ pointers. For more complex output, use `@cuprintf` directly.
 Limited string interpolation is also possible:
 
     @cuprint("Hello, World ", 42, "\n")
-    @cuprint "Hello, World $(42)\n"
+    @cuprint "Hello, World \$(42)\n"
 
 """
 macro cuprint(parts...)

--- a/src/execution.jl
+++ b/src/execution.jl
@@ -214,7 +214,8 @@ cudaconvert(arg) = adapt(Adaptor(), arg)
 abstract type AbstractKernel{F,TT} end
 
 # FIXME: there doesn't seem to be a way to access the documentation for the call-syntax,
-#        so attach it to the type
+#        so attach it to the type -- https://github.com/JuliaDocs/Documenter.jl/issues/558
+
 """
     (::HostKernel)(args...; kwargs...)
     (::DeviceKernel)(args...; kwargs...)


### PR DESCRIPTION
You can do interpolation into docstrings, so it would currently show up as `@cuprint "Hello, World 42\n"` in the manual, which would, I'd argue, defeats the purpose of the example :slightly_smiling_face: 