### PR TITLE
Rename atan2 to atan

### DIFF
--- a/src/device/cuda/math.jl
+++ b/src/device/cuda/math.jl
@@ -32,8 +32,8 @@
 @inline atan(x::Float64) = @wrap __nv_atan(x::double)::double
 @inline atan(x::Float32) = @wrap __nv_atanf(x::float)::float
 
-@inline atan2(x::Float64, y::Float64) = @wrap __nv_atan2(x::double, y::double)::double
-@inline atan2(x::Float32, y::Float32) = @wrap __nv_atan2f(x::float, y::float)::float
+@inline atan(x::Float64, y::Float64) = @wrap __nv_atan2(x::double, y::double)::double
+@inline atan(x::Float32, y::Float32) = @wrap __nv_atan2f(x::float, y::float)::float
 
 
 ## hyperbolic


### PR DESCRIPTION
To be consistent with Julia's `atan(x, y)` function, I renamed `atan2` to `atan`.
Here's the help message for atan:
```
atan(y)
atan(y, x)

Compute the inverse tangent of y or y/x, respectively.

For one argument, this is the angle in radians between the positive x-axis and the point (1, y), returning a value in the interval [-\pi/2, \pi/2].

For two arguments, this is the angle in radians between the positive x-axis and the point (x, y), returning a value in the interval [-\pi, \pi]. This corresponds to a standard
atan2 (https://en.wikipedia.org/wiki/Atan2) function.
```