### PR TITLE
Reduce number of threads used during shmem tests.

### DIFF
--- a/test/device/cuda.jl
+++ b/test/device/cuda.jl
@@ -248,7 +248,7 @@ end
 
 @testset "shared memory" begin
 
-n = 1024
+n = 256
 
 @testset "constructors" begin
     # static


### PR DESCRIPTION
Avoids running out of resources on certain platforms. Fixes #444.