### PR TITLE
[skip ci] Ignore CITATION.bib and test/perf for language count

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+CITATION.bib linguist-detectable=false
+test/perf/* linguist-detectable=false


### PR DESCRIPTION
After this, I get:
```
% github-linguist --breakdown
100.00% Julia

Julia:
src/CUDAnative.jl
src/compiler.jl
src/compiler/common.jl
src/compiler/debug.jl
src/compiler/driver.jl
src/compiler/irgen.jl
src/compiler/mcgen.jl
src/compiler/optim.jl
src/compiler/rtlib.jl
src/compiler/validation.jl
src/deprecated.jl
src/device/array.jl
src/device/cuda.jl
src/device/cuda/assertion.jl
src/device/cuda/atomics.jl
src/device/cuda/cooperative_groups.jl
src/device/cuda/dynamic_parallelism.jl
src/device/cuda/indexing.jl
src/device/cuda/math.jl
src/device/cuda/memory_dynamic.jl
src/device/cuda/memory_shared.jl
src/device/cuda/misc.jl
src/device/cuda/output.jl
src/device/cuda/synchronization.jl
src/device/cuda/warp_shuffle.jl
src/device/cuda/warp_vote.jl
src/device/llvm.jl
src/device/pointer.jl
src/device/runtime.jl
src/device/tools.jl
src/execution.jl
src/init.jl
src/reflection.jl
src/utils.jl
test/array.jl
test/base.jl
test/codegen.jl
test/device/array.jl
test/device/codegen.jl
test/device/cuda.jl
test/device/execution.jl
test/device/pointer.jl
test/examples.jl
test/pointer.jl
test/runtests.jl
test/util.jl
```