### PR TITLE
Improvements to shfl

### DIFF
--- a/test/device/cuda.jl
+++ b/test/device/cuda.jl
@@ -524,8 +524,25 @@ end
 @testset "data movement and conversion" begin
 
 if capability(dev) >= v"3.0"
-@testset "shuffle down" begin
 
+@testset "shuffle idx" begin
+    function kernel(d)
+        i = threadIdx().x
+        j = 32 - i + 1
+
+        d[i] = shfl(d[i], j)
+
+        return
+    end
+
+    warpsize = CUDAdrv.warpsize(device())
+
+    a = CuTestArray([i for i in 1:warpsize])
+    @cuda threads=warpsize kernel(a)
+    @test Array(a) == [i for i in warpsize:-1:1]
+end
+
+@testset "shuffle down" begin
     @eval struct AddableTuple
         x::Int32
         y::Int64
@@ -553,8 +570,8 @@ if capability(dev) >= v"3.0"
         a[1:n÷2] += a[n÷2+1:end]
         @test a == Array(d_a)
     end
-
 end
+
 end
 
 end


### PR DESCRIPTION
Use LLVM intrinsics, and have `shfl_idx` use 1-based indexing.