### PR TITLE
Use a module exception flag instead of trapping the GPU.

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -21,8 +21,10 @@ uuid = "3895d2a7-ec45-59b8-82bb-cfc6a382f9b3"
 version = "1.2.0"
 
 [[CUDAdrv]]
-deps = ["CUDAapi", "Libdl", "Printf"]
-git-tree-sha1 = "9ce99b5732c70e06ed97c042187baed876fb1698"
+deps = ["CEnum", "CUDAapi", "Libdl", "Printf"]
+git-tree-sha1 = "5d739aece437581b5d44783db90c2488973f8721"
+repo-rev = "master"
+repo-url = "https://github.com/JuliaGPU/CUDAdrv.jl.git"
 uuid = "c5f51814-7f29-56b8-a69c-e4d8f6be1fde"
 version = "3.1.0"
 

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -22,7 +22,7 @@ version = "1.2.0"
 
 [[CUDAdrv]]
 deps = ["CEnum", "CUDAapi", "Libdl", "Printf"]
-git-tree-sha1 = "5d739aece437581b5d44783db90c2488973f8721"
+git-tree-sha1 = "28cfedead47461f6b3cc71b90283165ac72634a4"
 repo-rev = "master"
 repo-url = "https://github.com/JuliaGPU/CUDAdrv.jl.git"
 uuid = "c5f51814-7f29-56b8-a69c-e4d8f6be1fde"

--- a/src/CUDAnative.jl
+++ b/src/CUDAnative.jl
@@ -127,6 +127,7 @@ include(joinpath("device", "runtime.jl"))
 
 include("compiler.jl")
 include("execution.jl")
+include("exceptions.jl")
 include("reflection.jl")
 
 include("deprecated.jl")

--- a/src/CUDAnative.jl
+++ b/src/CUDAnative.jl
@@ -125,14 +125,14 @@ include(joinpath("device", "cuda.jl"))
 include(joinpath("device", "llvm.jl"))
 include(joinpath("device", "runtime.jl"))
 
+include("init.jl")
+
 include("compiler.jl")
 include("execution.jl")
 include("exceptions.jl")
 include("reflection.jl")
 
 include("deprecated.jl")
-
-include("init.jl")
 
 
 ## initialization

--- a/src/compiler/driver.jl
+++ b/src/compiler/driver.jl
@@ -218,7 +218,6 @@ function codegen(target::Symbol, job::CompilerJob;
     end
 
     @timeit to[] "CUDA object generation" begin
-
         # enable debug options based on Julia's debug setting
         jit_options = Dict{CUDAdrv.CUjit_option,Any}()
         if Base.JLOptions().debug_level == 1

--- a/src/compiler/irgen.jl
+++ b/src/compiler/irgen.jl
@@ -240,6 +240,9 @@ function irgen(job::CompilerJob, method_instance::Core.MethodInstance, world)
         end
     end
 
+    # add the global exception indicator flag
+    emit_exception_flag!(mod)
+
     # rename the entry point
     if job.name !== nothing
         llvmfn = safe_fn(string("julia_", job.name))
@@ -374,6 +377,9 @@ function emit_exception!(builder, name, inst)
         end
     end
 
+    # signal the exception
+    call!(builder, Runtime.get(:signal_exception))
+
     trap = if haskey(functions(mod), "llvm.trap")
         functions(mod)["llvm.trap"]
     else
@@ -506,7 +512,7 @@ function hide_trap!(mod::LLVM.Module)
 
     # inline assembly to exit a thread, hiding control flow from LLVM
     exit_ft = LLVM.FunctionType(LLVM.VoidType(JuliaContext()))
-    exit = InlineAsm(exit_ft, "trap;", "", true)
+    exit = InlineAsm(exit_ft, "exit;", "", true)
 
     if haskey(functions(mod), "llvm.trap")
         trap = functions(mod)["llvm.trap"]
@@ -527,4 +533,40 @@ function hide_trap!(mod::LLVM.Module)
 
     end
     return changed
+end
+
+# emit a global variable for storing the current exception status
+#
+# since we don't actually support globals, access to this variable is done by calling the
+# cudanativeExceptionFlag function (lowered here to actual accesses of the variable)
+function emit_exception_flag!(mod::LLVM.Module)
+    # add the global variable
+    T_ptr = convert(LLVMType, Ptr{Cvoid})
+    gv = GlobalVariable(mod, T_ptr, "exception_flag")
+    initializer!(gv, LLVM.ConstantInt(T_ptr, 0))
+    linkage!(gv, LLVM.API.LLVMWeakAnyLinkage)
+    extinit!(gv, true)
+
+    # lower uses of the getter
+    if haskey(functions(mod), "cudanativeExceptionFlag")
+        buf_getter = functions(mod)["cudanativeExceptionFlag"]
+        @assert return_type(eltype(llvmtype(buf_getter))) == eltype(llvmtype(gv))
+
+        # find uses
+        worklist = Vector{LLVM.CallInst}()
+        for use in uses(buf_getter)
+            call = user(use)::LLVM.CallInst
+            push!(worklist, call)
+        end
+
+        # replace uses by a load from the global variable
+        for call in worklist
+            Builder(JuliaContext()) do builder
+                position!(builder, call)
+                ptr = load!(builder, gv)
+                replace_uses!(call, ptr)
+            end
+            unsafe_delete!(LLVM.parent(call), call)
+        end
+    end
 end

--- a/src/exceptions.jl
+++ b/src/exceptions.jl
@@ -1,0 +1,62 @@
+
+# support for device-side exceptions
+
+## exception type
+
+struct KernelException <: Exception
+    dev::CuDevice
+end
+
+function Base.showerror(io::IO, err::KernelException)
+    print(io, "KernelException: exception thrown during kernel execution on device $(CUDAdrv.name(err.dev))")
+end
+
+Base.show(io::IO, err::KernelException) = print(io, "KernelException($(err.device))")
+
+
+## exception handling
+
+const exception_flags = Dict{CuDevice, Mem.HostBuffer}()
+
+# create a CPU/GPU exception flag for error signalling, and put it in the module
+#
+# also see compiler/irgen.jl::emit_exception_flag!
+function create_exceptions!(mod::CuModule)
+    ctx = mod.ctx
+    dev = device(ctx)
+    try
+        flag_ptr = CuGlobal{Ptr{Cvoid}}(mod, "exception_flag")
+        exception_flag = get!(exception_flags, dev, Mem.alloc(Mem.Host, sizeof(Int),
+                            Mem.HOSTALLOC_DEVICEMAP))
+        flag_ptr[] = reinterpret(Ptr{Cvoid}, convert(CuPtr{Cvoid}, exception_flag))
+    catch err
+        # modules that do not throw exceptions will not contain the indicator flag
+        if err !== CUDAdrv.ERROR_NOT_FOUND
+            rethrow()
+        end
+    end
+
+    CUDAdrv.apicall_hook[] = check_exception_hook
+
+    return
+end
+
+function check_exceptions()
+    for (dev,buf) in exception_flags
+        ptr = convert(Ptr{Int}, buf)
+        flag = unsafe_load(ptr)
+        if flag !== 0
+            unsafe_store!(ptr, 0)
+            throw(KernelException(dev))
+        end
+    end
+    return
+end
+
+# check the exception flags on every API call, similarly to how CUDA handles errors
+function check_exception_hook(apicall)
+    # ... but don't do it for some very frequently called functions
+    if apicall !== :cuCtxGetCurrent
+        check_exceptions()
+    end
+end

--- a/src/exceptions.jl
+++ b/src/exceptions.jl
@@ -46,12 +46,14 @@ end
 
 function check_exceptions()
     for (ctx,buf) in exception_flags
-        ptr = convert(Ptr{Int}, buf)
-        flag = unsafe_load(ptr)
-        if flag !== 0
-            unsafe_store!(ptr, 0)
-            dev = device(ctx)
-            throw(KernelException(dev))
+        if CUDAdrv.isvalid(ctx)
+            ptr = convert(Ptr{Int}, buf)
+            flag = unsafe_load(ptr)
+            if flag !== 0
+                unsafe_store!(ptr, 0)
+                dev = device(ctx)
+                throw(KernelException(dev))
+            end
         end
     end
     return

--- a/src/exceptions.jl
+++ b/src/exceptions.jl
@@ -17,6 +17,10 @@ Base.show(io::IO, err::KernelException) = print(io, "KernelException($(err.devic
 ## exception handling
 
 const exception_flags = Dict{CuDevice, Mem.HostBuffer}()
+push!(device_reset!_listeners, (dev, ctx) -> begin
+    # invalidate exception flags when the device resets
+    delete!(exception_flags, dev)
+end)
 
 # create a CPU/GPU exception flag for error signalling, and put it in the module
 #

--- a/src/exceptions.jl
+++ b/src/exceptions.jl
@@ -11,7 +11,7 @@ function Base.showerror(io::IO, err::KernelException)
     print(io, "KernelException: exception thrown during kernel execution on device $(CUDAdrv.name(err.dev))")
 end
 
-Base.show(io::IO, err::KernelException) = print(io, "KernelException($(err.device))")
+Base.show(io::IO, err::KernelException) = print(io, "KernelException($(err.dev))")
 
 
 ## exception handling

--- a/src/execution.jl
+++ b/src/execution.jl
@@ -335,6 +335,15 @@ end
 
 const agecache = Dict{UInt, UInt}()
 const compilecache = Dict{UInt, HostKernel}()
+push!(device_reset!_listeners, (dev, ctx) -> begin
+    # invalidate compiled kernels when the device resets
+    for id in collect(keys(compilecache))
+        kernel = compilecache[id]
+        if kernel.ctx == ctx
+            delete!(compilecache, id)
+        end
+    end
+end)
 
 """
     cufunction(f, tt=Tuple{}; kwargs...)

--- a/src/execution.jl
+++ b/src/execution.jl
@@ -399,6 +399,7 @@ when function changes, or when different types or keyword arguments are provided
                    Memory usage: $(Base.format_bytes(mem.local)) local, $(Base.format_bytes(mem.shared)) shared, $(Base.format_bytes(mem.constant)) constant"""
             end
             compilecache[key] = kernel
+            create_exceptions!(mod)
         end
 
         return compilecache[key]::HostKernel{f,tt}

--- a/test/device/execution.jl
+++ b/test/device/execution.jl
@@ -542,23 +542,20 @@ script = """
 
 let (code, out, err) = julia_script(script, `-g0`)
     @test code == 1
-    @test occursin("ERROR: CUDA error: an illegal instruction was encountered", err) ||
-          occursin("ERROR: CUDA error: unspecified launch failure", err)
+    @test occursin("ERROR: KernelException: exception thrown during kernel execution on device", err)
     @test isempty(out)
 end
 
 let (code, out, err) = julia_script(script, `-g1`)
     @test code == 1
-    @test occursin("ERROR: CUDA error: an illegal instruction was encountered", err) ||
-          occursin("ERROR: CUDA error: unspecified launch failure", err)
+    @test occursin("ERROR: KernelException: exception thrown during kernel execution on device", err)
     @test occursin("ERROR: a exception was thrown during kernel execution", out)
     @test occursin("Run Julia on debug level 2 for device stack traces", out)
 end
 
 let (code, out, err) = julia_script(script, `-g2`)
     @test code == 1
-    @test occursin("ERROR: CUDA error: an illegal instruction was encountered", err) ||
-          occursin("ERROR: CUDA error: unspecified launch failure", err)
+    @test occursin("ERROR: KernelException: exception thrown during kernel execution on device", err)
     @test occursin("ERROR: a exception was thrown during kernel execution", out)
     if VERSION < v"1.3.0-DEV.270"
         @test occursin("[1] Type at float.jl", out)
@@ -585,8 +582,7 @@ script = """
 
 let (code, out, err) = julia_script(script, `-g2`)
     @test code == 1
-    @test occursin("ERROR: CUDA error: an illegal instruction was encountered", err) ||
-          occursin("ERROR: CUDA error: unspecified launch failure", err)
+    @test occursin("ERROR: KernelException: exception thrown during kernel execution on device", err)
     @test occursin("ERROR: a exception was thrown during kernel execution", out)
     @test occursin("foo at none:1", out)
     @test occursin("bar at none:2", out)


### PR DESCRIPTION
This is a promising change, making it possible to throw exceptions without killing the GPU:

```julia
julia> @cuda ((a)->(a[2]=1;return))(CuArray([1]))

julia> ERROR: a exception was thrown during kernel execution.
       Run Julia on debug level 2 for device stack traces.
julia> 

julia> synchronize()
ERROR: KernelException: exception thrown during kernel execution on device Quadro RTX 5000
Stacktrace:
 [1] check_exceptions() at /home/tim/Julia/pkg/CUDAnative/src/exceptions.jl:50
 [2] check_exception_hook(::Symbol) at /home/tim/Julia/pkg/CUDAnative/src/exceptions.jl:60
 [3] macro expansion at /home/tim/Julia/pkg/CUDAdrv/src/error.jl:94 [inlined]
 [4] cuCtxSynchronize() at /home/tim/Julia/pkg/CUDAdrv/src/libcuda.jl:156
 [5] synchronize() at /home/tim/Julia/pkg/CUDAdrv/src/context.jl:185
 [6] top-level scope at REPL[8]:1

julia> @cuda ((a)->(a[2]=1;return))(CuArray([1,2]))

julia> synchronize()
```

Illegal memory errors etc. still break CUDA, but many of those should be guarded by bounds checks and our IR verifier.