### PR TITLE
Initialization improvements

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -103,7 +103,7 @@ cuarrays:
                           Pkg.instantiate()'
     - julia --project=$CUARRAYS -e 'using Pkg;
                                     Pkg.instantiate();
-                                    Pkg.add(["FFTW", "ForwardDiff"])'
+                                    Pkg.add(["FFTW", "ForwardDiff", "FillArrays"])'
     - JULIA_LOAD_PATH=".:$CUARRAYS::" julia $CUARRAYS/test/runtests.jl
   allow_failure: true
 


### PR DESCRIPTION
- silence load-time warnings, as the environment flag didn't always work
- use a module flag to indicate success
- allow global usage