### PR TITLE
Add addrspacecast function

### DIFF
--- a/src/device/pointer.jl
+++ b/src/device/pointer.jl
@@ -276,3 +276,32 @@ end
 @inline unsafe_cached_load(p::DevicePtr{T,AS.Global}, i::Integer=1, args...) where {T} =
     recurse_pointer_invocation(unsafe_cached_load, p+sizeof(T)*Int(i-one(i)),
                                CachedLoadPointers, 1, args...)
+
+export addrspacecast
+
+@generated function addrspacecast(p::DevicePtr{T, AS}) where {T, AS}
+    # types
+    eltyp = convert(LLVMType, T)
+    T_ptr = convert(LLVMType, DevicePtr{T, AS})
+
+    T_actual_ptr = LLVM.PointerType(eltyp)
+    T_actual_ptr_as = LLVM.PointerType(eltyp, convert(Int, AS))
+
+    # create function
+    param_types = [T_ptr]
+    llvm_f, _ = create_function(T_ptr, param_types)
+
+    # generate LLVM IR
+    Builder(JuliaContext()) do builder
+        entry = BasicBlock(llvm_f, "entry", JuliaContext())
+        position!(builder, entry)
+
+        ptr = inttoptr!(builder, parameters(llvm_f)[1], T_actual_ptr)
+        ptr_with_as = addrspacecast!(builder, ptr, T_actual_ptr_as)
+        ret = ptrtoint!(builder, ptr_with_as, LLVM.Int64Type(JuliaContext()))
+
+        ret!(builder, ret)
+    end
+
+    call_function(llvm_f, DevicePtr{T, AS}, Tuple{DevicePtr{T, AS}}, :((p,)))
+end


### PR DESCRIPTION
This PR adds an `addrspacecast` function that wraps LLVM's `addrspacecast`. This is useful to subtract the base address of e.g. the shared AS window from the value stored in `DevicePtr`s.

```julia
julia> code_llvm(addrspacecast, Tuple{CUDAnative.DevicePtr{Float32, AS.Generic}})

;  @ /home/tfaingna/.julia/dev/CUDAnative/src/device/pointer.jl:284 within `addrspacecast'
define i64 @julia_addrspacecast_18076(i64) {
top:
; ┌ @ /home/tfaingna/.julia/dev/CUDAnative/src/device/pointer.jl:284 within `macro expansion'
   ret i64 %0
; └
}

julia> code_llvm(addrspacecast, Tuple{CUDAnative.DevicePtr{Float32, AS.Shared}})

;  @ /home/tfaingna/.julia/dev/CUDAnative/src/device/pointer.jl:284 within `addrspacecast'
define i64 @julia_addrspacecast_17283(i64) {
top:
; ┌ @ /home/tfaingna/.julia/dev/CUDAnative/src/device/pointer.jl:284 within `macro expansion' @ /home/tfaingna/.julia/packages/LLVM/ICZSf/src/interop/base.jl:52
   %1 = inttoptr i64 %0 to float*
   %2 = addrspacecast float* %1 to float addrspace(3)*
   %3 = ptrtoint float addrspace(3)* %2 to i64
; │ @ /home/tfaingna/.julia/dev/CUDAnative/src/device/pointer.jl:284 within `macro expansion'
   ret i64 %3
; └
}
```

This is in reference to point 2 of https://github.com/JuliaGPU/CUDAnative.jl/pull/494#issuecomment-554441290, but since the change is rather self-contained, I decided to open a new PR for it to separate it from WMMA.
This might also prove useful to transition some `@generated` functions over to `ccall`, say https://github.com/JuliaGPU/CUDAnative.jl/blob/b55dee83f0cf4e51c937e449cb30f5e0101c846e/src/device/pointer.jl#L219.