### PR TITLE
Fix compatibility with older GPUArrays.

### DIFF
--- a/src/device/cuda/memory_shared.jl
+++ b/src/device/cuda/memory_shared.jl
@@ -55,6 +55,11 @@ end
 @generated function _shmem(::Val{id}, ::Type{T}, ::Val{len}=Val(0)) where {id,T,len}
     eltyp = convert(LLVMType, T)
 
+    # old versions of GPUArrays invoke _shmem with an integer id; make sure those are unique
+    if !isa(id, String) || !isa(id, Symbol)
+        id = "shmem$id"
+    end
+
     T_ptr = convert(LLVMType, DevicePtr{T,AS.Shared})
     T_actual_ptr = LLVM.PointerType(eltyp)
 


### PR DESCRIPTION
Old versions of GPUArrays invoke `_shmem` with an integer id; make sure those are unique to pass `ptxas`.

Fixes issue introduced by https://github.com/JuliaGPU/CUDAnative.jl/pull/533