### PR TITLE
Use the Julia LLVM IR printer to support the debuginfo argument.

### DIFF
--- a/test/codegen.jl
+++ b/test/codegen.jl
@@ -152,13 +152,13 @@ end
     for f in (load, store)
         ir = sprint(io->CUDAnative.code_llvm(io, f,
                                              Tuple{CUDAnative.DevicePtr{Float32,AS.Global}};
-                                             dump_module=true))
+                                             dump_module=true, raw=true))
         @test occursin("ptxtbaa_global", ir)
 
         # no TBAA on generic pointers
         ir = sprint(io->CUDAnative.code_llvm(io, f,
                                              Tuple{CUDAnative.DevicePtr{Float32,AS.Generic}};
-                                             dump_module=true))
+                                             dump_module=true, raw=true))
         @test !occursin("ptxtbaa", ir)
     end
 
@@ -167,7 +167,7 @@ end
 
     ir = sprint(io->CUDAnative.code_llvm(io, cached_load,
                                          Tuple{CUDAnative.DevicePtr{Float32,AS.Global}};
-                                         dump_module=true))
+                                         dump_module=true, raw=true))
     @test occursin("ptxtbaa_global", ir)
 end
 

--- a/test/device/cuda.jl
+++ b/test/device/cuda.jl
@@ -20,7 +20,7 @@
 
     @testset "range metadata" begin
         foobar() = threadIdx().x
-        ir = sprint(io->CUDAnative.code_llvm(io, foobar, Tuple{}))
+        ir = sprint(io->CUDAnative.code_llvm(io, foobar, Tuple{}; raw=true))
 
         @test occursin(r"call .+ @llvm.nvvm.read.ptx.sreg.tid.x.+ !range", ir)
     end


### PR DESCRIPTION
Integrate with Base's IR printer:

```llvm
julia> a = CuArray([1])
1-element CuArray{Int64,1,Nothing}:
 1

julia> @device_code_llvm a .= 2

define void @ptxcall_anonymous27_27({ [1 x i64], i64 }, { [1 x i64], [1 x { i64 }] }) local_unnamed_addr {
entry:
  %2 = alloca { [1 x { i64 }] }, align 8
  %3 = alloca [1 x i64], align 8
  %.fca.0.0.extract1 = extractvalue { [1 x i64], i64 } %0, 0, 0
  %4 = bitcast { [1 x { i64 }] }* %2 to i8*
  call void @llvm.lifetime.start.p0i8(i64 8, i8* %4)
  %5 = bitcast [1 x i64]* %3 to i8*
  call void @llvm.lifetime.start.p0i8(i64 8, i8* %5)
;  @ /home/tim/Julia/pkg/GPUArrays/src/host/broadcast.jl:59 within `#27'
; ┌ @ /home/tim/Julia/pkg/GPUArrays/src/device/indexing.jl:50 within `macro expansion'
; │┌ @ /home/tim/Julia/pkg/GPUArrays/src/device/indexing.jl:28 within `linear_index'
; ││┌ @ /home/tim/Julia/pkg/CuArrays/src/gpuarrays.jl:31 within `blockidx'
; │││┌ @ /home/tim/Julia/pkg/CUDAnative/src/device/cuda/indexing.jl:75 within `blockIdx'
; ││││┌ @ /home/tim/Julia/pkg/CUDAnative/src/device/cuda/indexing.jl:55 within `blockIdx_x'
; │││││┌ @ /home/tim/Julia/pkg/CUDAnative/src/device/cuda/indexing.jl:8 within `_index'
; ││││││┌ @ /home/tim/Julia/pkg/CUDAnative/src/device/cuda/indexing.jl:8 within `macro expansion' @ /home/tim/Julia/pkg/LLVM/src/interop/base.jl:52
         %6 = call i32 @llvm.nvvm.read.ptx.sreg.ctaid.x()
; │││││└└
; │││││┌ @ boot.jl:710 within `Int64'
; ││││││┌ @ boot.jl:634 within `toInt64'
         %7 = zext i32 %6 to i64
; ││└└└└└
; ││┌ @ /home/tim/Julia/pkg/CuArrays/src/gpuarrays.jl:32 within `blockdim'
; │││┌ @ /home/tim/Julia/pkg/CUDAnative/src/device/cuda/indexing.jl:82 within `blockDim'
; ││││┌ @ /home/tim/Julia/pkg/CUDAnative/src/device/cuda/indexing.jl:50 within `blockDim_x'
; │││││┌ @ /home/tim/Julia/pkg/CUDAnative/src/device/cuda/indexing.jl:8 within `_index'
; ││││││┌ @ /home/tim/Julia/pkg/CUDAnative/src/device/cuda/indexing.jl:8 within `macro expansion' @ /home/tim/Julia/pkg/LLVM/src/interop/base.jl:52
         %8 = call i32 @llvm.nvvm.read.ptx.sreg.ntid.x()
; │││││└└
; │││││┌ @ boot.jl:710 within `Int64'
; ││││││┌ @ boot.jl:634 within `toInt64'
         %9 = zext i32 %8 to i64
; ││└└└└└
; ││┌ @ int.jl:54 within `*'
     %10 = mul nuw nsw i64 %9, %7
; ││└
; ││┌ @ /home/tim/Julia/pkg/CuArrays/src/gpuarrays.jl:33 within `threadidx'
; │││┌ @ /home/tim/Julia/pkg/CUDAnative/src/device/cuda/indexing.jl:89 within `threadIdx'
; ││││┌ @ /home/tim/Julia/pkg/CUDAnative/src/device/cuda/indexing.jl:45 within `threadIdx_x'
; │││││┌ @ /home/tim/Julia/pkg/CUDAnative/src/device/cuda/indexing.jl:8 within `_index'
; ││││││┌ @ /home/tim/Julia/pkg/CUDAnative/src/device/cuda/indexing.jl:8 within `macro expansion' @ /home/tim/Julia/pkg/LLVM/src/interop/base.jl:52
         %11 = call i32 @llvm.nvvm.read.ptx.sreg.tid.x()
; │││││└└
; │││││┌ @ int.jl:53 within `+'
        %addconv = add nuw nsw i32 %11, 1
        %12 = zext i32 %addconv to i64
; ││└└└└
; ││┌ @ int.jl:53 within `+'
     %13 = add nuw nsw i64 %10, %12
; │└└
; │ @ /home/tim/Julia/pkg/GPUArrays/src/device/indexing.jl:51 within `macro expansion'
; │┌ @ operators.jl:294 within `>'
; ││┌ @ int.jl:49 within `<'
     %14 = icmp slt i64 %.fca.0.0.extract1, %13
; │└└
   br i1 %14, label %L31.i, label %L32.i

L31.i:                                            ; preds = %entry
   call void @llvm.lifetime.end.p0i8(i64 8, i8* %4)
   call void @llvm.lifetime.end.p0i8(i64 8, i8* %5)
   br label %julia_anonymous27_27.exit

L32.i:                                            ; preds = %entry
; │ @ /home/tim/Julia/pkg/GPUArrays/src/device/indexing.jl:65 within `macro expansion'
; │┌ @ multidimensional.jl:259 within `CartesianIndices'
; ││┌ @ abstractarray.jl:75 within `axes'
; │││┌ @ tuple.jl:139 within `map'
; ││││┌ @ range.jl:320 within `OneTo' @ range.jl:311
; │││││┌ @ promotion.jl:412 within `max'
        %15 = icmp sgt i64 %.fca.0.0.extract1, 0
        %16 = select i1 %15, i64 %.fca.0.0.extract1, i64 0
; ││└└└└
; ││ @ multidimensional.jl:259 within `CartesianIndices' @ multidimensional.jl:247 @ multidimensional.jl:247
    %.sroa.017.0..sroa_idx18 = getelementptr inbounds { [1 x { i64 }] }, { [1 x { i64 }] }* %2, i64 0, i32 0, i64 0, i32 0
    store i64 %16, i64* %.sroa.017.0..sroa_idx18, align 8
; └└
; ┌ @ multidimensional.jl:312 within `getindex'
   %17 = getelementptr inbounds [1 x i64], [1 x i64]* %3, i64 0, i64 0
   store i64 %13, i64* %17, align 8
; │┌ @ abstractarray.jl:503 within `checkbounds' @ abstractarray.jl:488
; ││┌ @ abstractarray.jl:560 within `checkindex'
; │││┌ @ int.jl:424 within `<='
      %18 = icmp sgt i64 %13, %16
; ││└└
; ││ @ abstractarray.jl:503 within `checkbounds'
    br i1 %18, label %L49.i, label %L48.i

L48.i:                                            ; preds = %L49.i, %L32.i
    %.fca.1.extract = extractvalue { [1 x i64], i64 } %0, 1
    %.fca.0.0.extract = extractvalue { [1 x i64], [1 x { i64 }] } %1, 0, 0
; └└
;  @ /home/tim/Julia/pkg/GPUArrays/src/host/broadcast.jl:60 within `#27'
; ┌ @ abstractarray.jl:1074 within `setindex!'
; │┌ @ abstractarray.jl:1093 within `_setindex!'
; ││┌ @ /home/tim/Julia/pkg/CUDAnative/src/device/array.jl:84 within `setindex!'
; │││┌ @ /home/tim/Julia/pkg/CUDAnative/src/device/pointer.jl:167 within `unsafe_store!'
; ││││┌ @ /home/tim/Julia/pkg/CUDAnative/src/device/pointer.jl:167 within `macro expansion' @ /home/tim/Julia/pkg/LLVM/src/interop/base.jl:52
; │││││┌ @ int.jl:52 within `-'
        %19 = add nsw i64 %13, -1
; │││││└
       %20 = inttoptr i64 %.fca.1.extract to i64*
       %21 = getelementptr i64, i64* %20, i64 %19
       %22 = addrspacecast i64* %21 to i64 addrspace(1)*
       store i64 %.fca.0.0.extract, i64 addrspace(1)* %22, align 8
; └└└└└
;  @ /home/tim/Julia/pkg/GPUArrays/src/host/broadcast.jl:62 within `#27'
  call void @llvm.lifetime.end.p0i8(i64 8, i8* %4)
  call void @llvm.lifetime.end.p0i8(i64 8, i8* %5)
  br label %julia_anonymous27_27.exit

L49.i:                                            ; preds = %L32.i
;  @ /home/tim/Julia/pkg/GPUArrays/src/host/broadcast.jl:59 within `#27'
; ┌ @ multidimensional.jl:312 within `getindex'
; │┌ @ abstractarray.jl:503 within `checkbounds'
    %23 = addrspacecast { [1 x { i64 }] }* %2 to { [1 x { i64 }] } addrspace(11)*
    %24 = addrspacecast [1 x i64]* %3 to [1 x i64] addrspace(11)*
    call fastcc void @julia_throw_boundserror_19303()
    call void asm sideeffect "exit;", ""() #3
    br label %L48.i

julia_anonymous27_27.exit:                        ; preds = %L48.i, %L31.i
    ret void
; └└
}
```

Bit verbose, but there's the `debuginfo` kwarg for that:

```llvm
julia> @device_code_llvm debuginfo=:none a .= 2

define void @ptxcall_anonymous27_28({ [1 x i64], i64 }, { [1 x i64], [1 x { i64 }] }) local_unnamed_addr {
entry:
  %2 = alloca { [1 x { i64 }] }, align 8
  %3 = alloca [1 x i64], align 8
  %.fca.0.0.extract1 = extractvalue { [1 x i64], i64 } %0, 0, 0
  %4 = bitcast { [1 x { i64 }] }* %2 to i8*
  call void @llvm.lifetime.start.p0i8(i64 8, i8* %4)
  %5 = bitcast [1 x i64]* %3 to i8*
  call void @llvm.lifetime.start.p0i8(i64 8, i8* %5)
  %6 = call i32 @llvm.nvvm.read.ptx.sreg.ctaid.x()
  %7 = zext i32 %6 to i64
  %8 = call i32 @llvm.nvvm.read.ptx.sreg.ntid.x()
  %9 = zext i32 %8 to i64
  %10 = mul nuw nsw i64 %9, %7
  %11 = call i32 @llvm.nvvm.read.ptx.sreg.tid.x()
  %addconv = add nuw nsw i32 %11, 1
  %12 = zext i32 %addconv to i64
  %13 = add nuw nsw i64 %10, %12
  %14 = icmp slt i64 %.fca.0.0.extract1, %13
  br i1 %14, label %L31.i, label %L32.i

L31.i:                                            ; preds = %entry
  call void @llvm.lifetime.end.p0i8(i64 8, i8* %4)
  call void @llvm.lifetime.end.p0i8(i64 8, i8* %5)
  br label %julia_anonymous27_28.exit

L32.i:                                            ; preds = %entry
  %15 = icmp sgt i64 %.fca.0.0.extract1, 0
  %16 = select i1 %15, i64 %.fca.0.0.extract1, i64 0
  %.sroa.017.0..sroa_idx18 = getelementptr inbounds { [1 x { i64 }] }, { [1 x { i64 }] }* %2, i64 0, i32 0, i64 0, i32 0
  store i64 %16, i64* %.sroa.017.0..sroa_idx18, align 8
  %17 = getelementptr inbounds [1 x i64], [1 x i64]* %3, i64 0, i64 0
  store i64 %13, i64* %17, align 8
  %18 = icmp sgt i64 %13, %16
  br i1 %18, label %L49.i, label %L48.i

L48.i:                                            ; preds = %L49.i, %L32.i
  %.fca.1.extract = extractvalue { [1 x i64], i64 } %0, 1
  %.fca.0.0.extract = extractvalue { [1 x i64], [1 x { i64 }] } %1, 0, 0
  %19 = add nsw i64 %13, -1
  %20 = inttoptr i64 %.fca.1.extract to i64*
  %21 = getelementptr i64, i64* %20, i64 %19
  %22 = addrspacecast i64* %21 to i64 addrspace(1)*
  store i64 %.fca.0.0.extract, i64 addrspace(1)* %22, align 8
  call void @llvm.lifetime.end.p0i8(i64 8, i8* %4)
  call void @llvm.lifetime.end.p0i8(i64 8, i8* %5)
  br label %julia_anonymous27_28.exit

L49.i:                                            ; preds = %L32.i
  %23 = addrspacecast { [1 x { i64 }] }* %2 to { [1 x { i64 }] } addrspace(11)*
  %24 = addrspacecast [1 x i64]* %3 to [1 x i64] addrspace(11)*
  call fastcc void @julia_throw_boundserror_19341()
  call void asm sideeffect "exit;", ""() #3
  br label %L48.i

julia_anonymous27_28.exit:                        ; preds = %L48.i, %L31.i
  ret void
}
```

cc @vchuravy 
