### PR TITLE
Run the inliner at the end of the pipeline.

### DIFF
--- a/src/compiler/irgen.jl
+++ b/src/compiler/irgen.jl
@@ -273,7 +273,6 @@ function irgen(job::CompilerJob, method_instance::Core.MethodInstance, world)
         add!(pm, ModulePass("LowerThrow", lower_throw!))
         add!(pm, FunctionPass("HideUnreachable", hide_unreachable!))
         add!(pm, ModulePass("HideTrap", hide_trap!))
-        always_inliner!(pm)
         run!(pm, mod)
     end
 

--- a/src/compiler/rtlib.jl
+++ b/src/compiler/rtlib.jl
@@ -68,7 +68,6 @@ function link_libdevice!(job::CompilerJob, mod::LLVM.Module, lib::LLVM.Module)
     ModulePassManager() do pm
         push!(metadata(mod), "nvvm-reflect-ftz",
               MDNode([ConstantInt(Int32(1), JuliaContext())]))
-        # TODO: run the reflect pass?
         run!(pm, mod)
     end
 end

--- a/test/codegen.jl
+++ b/test/codegen.jl
@@ -210,6 +210,16 @@ end
     @test !occursin("\bstore\b", ir)
 end
 
+@testset "CUDAnative.jl#553" begin
+    function kernel(ptr)
+       unsafe_store!(ptr, CUDAnative.fma(unsafe_load(ptr), unsafe_load(ptr,2), unsafe_load(ptr,3)))
+       return
+    end
+
+    ir = sprint(io->CUDAnative.code_llvm(io, kernel, Tuple{Ptr{Float32}}))
+    @test !occursin("@__nv_fmaf", ir)
+end
+
 end
 
 


### PR DESCRIPTION
This works around its inability to deal with Julia's operand bundles.
Fixes https://github.com/JuliaGPU/CUDAnative.jl/issues/553