### PR TITLE
use --startup=no in spawned tests

### DIFF
--- a/test/examples.jl
+++ b/test/examples.jl
@@ -19,10 +19,10 @@ cd(examples_dir) do
     examples = relpath.(examples, Ref(examples_dir))
     @testset for example in examples
         # construct a command
-        cmd = `$(Base.julia_cmd())`
+        cmd = `$(Base.julia_cmd()) --startup=no`
         if Base.JLOptions().project != C_NULL
             # --project isn't preserved by julia_cmd()
-            cmd = `$cmd --project=$(unsafe_string(Base.JLOptions().project)) --startup=no`
+            cmd = `$cmd --project=$(unsafe_string(Base.JLOptions().project))`
         end
         cmd = `$cmd $example`
 

--- a/test/examples.jl
+++ b/test/examples.jl
@@ -22,7 +22,7 @@ cd(examples_dir) do
         cmd = `$(Base.julia_cmd())`
         if Base.JLOptions().project != C_NULL
             # --project isn't preserved by julia_cmd()
-            cmd = `$cmd --project=$(unsafe_string(Base.JLOptions().project))`
+            cmd = `$cmd --project=$(unsafe_string(Base.JLOptions().project)) --startup=no`
         end
         cmd = `$cmd $example`
 


### PR DESCRIPTION
The test suite involves spinning up new julia instances, but these can end up loading the users startup.jl which is undesirable. 