### PR TITLE
Simplify naming of wrapper kernels.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -34,15 +34,15 @@ julia:nightly:
     CI_THOROUGH: 'true'
   allow_failure: true
 
-julia:1.3-debug:
+julia:1.4-debug:
   extends:
     - .julia:source
     - .test
   tags:
     - nvidia
   variables:
-    CI_CLONE_ARGS: '-b release-1.3'
-    CI_BUILD_ARGS: 'debug'
+    CI_CLONE_ARGS: '-b release-1.4'
+    CI_BUILD_ARGS: 'BINARYBUILDER_LLVM_ASSERTS=1 debug'
   allow_failure: true
 
 

--- a/src/compiler/irgen.jl
+++ b/src/compiler/irgen.jl
@@ -721,15 +721,6 @@ function wrap_entry!(job::CompilerJob, mod::LLVM.Module, entry_f::LLVM.Function)
     wrapper_ft = LLVM.FunctionType(LLVM.VoidType(JuliaContext()), wrapper_types)
     wrapper_f = LLVM.Function(mod, wrapper_fn, wrapper_ft)
 
-    # Get debuginfo from the entry_f and copy it to the wrapper_f
-    # on -g0 julia does not add a DICU and DISP object
-    if LLVM.version() >= v"8.0"
-        if Base.JLOptions().debug_level > 0
-            SP = LLVM.get_subprogram(entry_f)
-            LLVM.set_subprogram!(wrapper_f, SP)
-        end
-    end
-
     # emit IR performing the "conversions"
     let builder = Builder(JuliaContext())
         entry = BasicBlock(wrapper_f, "entry", JuliaContext())

--- a/test/codegen.jl
+++ b/test/codegen.jl
@@ -80,7 +80,7 @@ end
     @test occursin(r"@.*julia_kernel.+\(({ i64 }|\[1 x i64\]) addrspace\(\d+\)?\*", ir)
 
     ir = sprint(io->CUDAnative.code_llvm(io, kernel, Tuple{Aggregate}; kernel=true))
-    @test occursin(r"@.*ptxcall_kernel.+\(({ i64 }|\[1 x i64\])\)", ir)
+    @test occursin(r"@.*julia_kernel.+\(({ i64 }|\[1 x i64\])\)", ir)
 end
 
 @testset "property_annotations" begin
@@ -140,9 +140,9 @@ end
     end
 
     test_name(regular, "julia_regular")
-    test_name(regular, "ptxcall_regular"; kernel=true)
+    test_name(regular, "julia_regular"; kernel=true)
     test_name(closure, "julia_anonymous")
-    test_name(closure, "ptxcall_anonymous"; kernel=true)
+    test_name(closure, "julia_anonymous"; kernel=true)
 end
 
 @testset "PTX TBAA" begin
@@ -267,7 +267,7 @@ end
     end
 
     asm = sprint(io->CUDAnative.code_ptx(io, entry, Tuple{Int64}; kernel=true))
-    @test occursin(r"\.visible \.entry .*ptxcall_entry", asm)
+    @test occursin(r"\.visible \.entry .*julia_entry", asm)
     @test !occursin(r"\.visible \.func .*julia_nonentry", asm)
     @test occursin(r"\.func .*julia_nonentry", asm)
 
@@ -396,9 +396,9 @@ end
     end
 
     test_name(regular, "julia_regular")
-    test_name(regular, "ptxcall_regular"; kernel=true)
+    test_name(regular, "julia_regular"; kernel=true)
     test_name(closure, "julia_anonymous")
-    test_name(closure, "ptxcall_anonymous"; kernel=true)
+    test_name(closure, "julia_anonymous"; kernel=true)
 end
 
 @testset "exception arguments" begin

--- a/test/device/execution.jl
+++ b/test/device/execution.jl
@@ -70,10 +70,10 @@ end
     @test_throws ErrorException @device_code_lowered nothing
 
     # make sure kernel name aliases are preserved in the generated code
-    @test occursin("ptxcall_dummy", sprint(io->(@device_code_llvm io=io optimize=false @cuda dummy())))
-    @test occursin("ptxcall_dummy", sprint(io->(@device_code_llvm io=io @cuda dummy())))
-    @test occursin("ptxcall_dummy", sprint(io->(@device_code_ptx io=io @cuda dummy())))
-    @test occursin("ptxcall_dummy", sprint(io->(@device_code_sass io=io @cuda dummy())))
+    @test occursin("julia_dummy", sprint(io->(@device_code_llvm io=io optimize=false @cuda dummy())))
+    @test occursin("julia_dummy", sprint(io->(@device_code_llvm io=io @cuda dummy())))
+    @test occursin("julia_dummy", sprint(io->(@device_code_ptx io=io @cuda dummy())))
+    @test occursin("julia_dummy", sprint(io->(@device_code_sass io=io @cuda dummy())))
 
     # make sure invalid kernels can be partially reflected upon
     let
@@ -96,7 +96,7 @@ end
     end
 
     # set name of kernel
-    @test occursin("ptxcall_mykernel", sprint(io->(@device_code_llvm io=io begin
+    @test occursin("julia_mykernel", sprint(io->(@device_code_llvm io=io begin
         k = cufunction(dummy, name="mykernel")
         k()
     end)))


### PR DESCRIPTION
Don't use a separate ptxcall naming scheme, as kernels are the only functions that get C++ mangled.

Also removes copying the debug info subprogram to the kernel wrapper, since that's apparently invalid: https://reviews.llvm.org/D32975. Ideally we'd create a distinct subprogram here, but the C API doesn't expose that functionality.