### PR TITLE
Print compilation job details when doing reflection.

### DIFF
--- a/src/compiler/common.jl
+++ b/src/compiler/common.jl
@@ -18,6 +18,19 @@ end
 CompilerJob(f, tt, cap, kernel; kwargs...) =
     CompilerJob(f=f, tt=tt, cap=cap, kernel=kernel; kwargs...)
 
+function Base.show(io::IO, job::CompilerJob)
+    print(io, "CUDAnative.CompilerJob for $(job.f)($(join(job.tt.parameters, ", ")))")
+
+    print(io, " (cap=$(job.cap.major).$(job.cap.minor)")
+    job.kernel && print(io, ", kernel=true")
+    job.minthreads !== nothing && print(io, ", minthreads=$(job.minthreads)")
+    job.maxthreads !== nothing && print(io, ", maxthreads=$(job.maxthreads)")
+    job.blocks_per_sm !== nothing && print(io, ", blocks_per_sm=$(job.blocks_per_sm)")
+    job.maxregs !== nothing && print(io, ", maxregs=$(job.maxregs)")
+    job.name !== nothing && print(io, ", name=$(job.name)")
+    print(io, ")")
+end
+
 # global job reference
 # FIXME: thread through `job` everywhere (deadlocks the Julia compiler when doing so with
 #        the LLVM passes in CUDAnative)

--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -256,16 +256,12 @@ See also: InteractiveUtils.@code_typed
 """
 macro device_code_typed(ex...)
     quote
-        buf = Any[]
+        output = Dict{CompilerJob,Any}()
         function hook(job::CompilerJob)
-            if VERSION >= v"1.1.0"
-                append!(buf, code_typed(job.f, job.tt, debuginfo=:source))
-            else
-                append!(buf, code_typed(job.f, job.tt))
-            end
+            output[job] = code_typed(job.f, job.tt)
         end
         $(emit_hooked_compilation(:hook, ex...))
-        buf
+        output
     end
 end
 
@@ -279,6 +275,8 @@ See also: InteractiveUtils.@code_warntype
 """
 macro device_code_warntype(ex...)
     function hook(job::CompilerJob; io::IO=stdout, kwargs...)
+        println(io, "$job")
+        println(io)
         code_warntype(io, job.f, job.tt; kwargs...)
     end
     emit_hooked_compilation(hook, ex...)
@@ -294,7 +292,10 @@ to `io` for every compiled CUDA kernel. For other supported keywords, see
 See also: InteractiveUtils.@code_llvm
 """
 macro device_code_llvm(ex...)
-    hook(job::CompilerJob; io::IO=stdout, kwargs...) = code_llvm(io, job; kwargs...)
+    function hook(job::CompilerJob; io::IO=stdout, kwargs...)
+        println(io, "; $job")
+        code_llvm(io, job; kwargs...)
+    end
     emit_hooked_compilation(hook, ex...)
 end
 
@@ -306,7 +307,11 @@ for every compiled CUDA kernel. For other supported keywords, see
 [`CUDAnative.code_ptx`](@ref).
 """
 macro device_code_ptx(ex...)
-    hook(job::CompilerJob; io::IO=stdout, kwargs...) = code_ptx(io, job; kwargs...)
+    function hook(job::CompilerJob; io::IO=stdout, kwargs...)
+        println(io, "// $job")
+        println(io)
+        code_ptx(io, job; kwargs...)
+    end
     emit_hooked_compilation(hook, ex...)
 end
 
@@ -318,7 +323,11 @@ Evaluates the expression `ex` and prints the result of [`CUDAnative.code_sass`](
 [`CUDAnative.code_sass`](@ref).
 """
 macro device_code_sass(ex...)
-    hook(job::CompilerJob; io::IO=stdout, kwargs...) = code_sass(io, job; kwargs...)
+    function hook(job::CompilerJob; io::IO=stdout, kwargs...)
+        println(io, "// $job")
+        println(io)
+        code_sass(io, job; kwargs...)
+    end
     emit_hooked_compilation(hook, ex...)
 end
 


### PR DESCRIPTION
device_code macros can capture multiple kernels, so prefix with the compiler job when outputting. also useful to capture what is being executed now that the (previously much too verbose) debug print of compiled kernels is gone.