### PR TITLE
remove `cached` CodegenParams kwarg in >= v"1.5.0-DEV.393"

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,16 +23,16 @@ julia:1.3:
   variables:
     CI_THOROUGH: 'true'
 
-# julia:nightly:
-#   extends:
-#     - .julia:nightly
-#     - .test
-#   tags:
-#     - nvidia
-#     - sm_75
-#   variables:
-#     CI_THOROUGH: 'true'
-#   allow_failure: true
+julia:nightly:
+  extends:
+    - .julia:nightly
+    - .test
+  tags:
+    - nvidia
+    - sm_75
+  variables:
+    CI_THOROUGH: 'true'
+  allow_failure: true
 
 # julia:1.4-debug:
 #   extends:

--- a/src/compiler/irgen.jl
+++ b/src/compiler/irgen.jl
@@ -127,7 +127,7 @@ function compile_method_instance(job::CompilerJob, method_instance::Core.MethodI
                     :module_activation  => hook_module_activation,
                     :emit_function      => hook_emit_function,
                     :emitted_function   => hook_emitted_function]
-     if VERSION >= v"1.5.0-DEV.423"
+    if VERSION >= v"1.5.0-DEV.423"
         push!(param_kwargs, :cached => false)
     end
     if LLVM.version() >= v"8.0" && VERSION >= v"1.3.0-DEV.547"

--- a/src/compiler/irgen.jl
+++ b/src/compiler/irgen.jl
@@ -127,7 +127,7 @@ function compile_method_instance(job::CompilerJob, method_instance::Core.MethodI
                     :module_activation  => hook_module_activation,
                     :emit_function      => hook_emit_function,
                     :emitted_function   => hook_emitted_function]
-    if VERSION >= v"1.5.0-DEV.423"
+    if VERSION < v"1.5.0-DEV.423"
         push!(param_kwargs, :cached => false)
     end
     if LLVM.version() >= v"8.0" && VERSION >= v"1.3.0-DEV.547"

--- a/src/compiler/irgen.jl
+++ b/src/compiler/irgen.jl
@@ -127,7 +127,7 @@ function compile_method_instance(job::CompilerJob, method_instance::Core.MethodI
                     :module_activation  => hook_module_activation,
                     :emit_function      => hook_emit_function,
                     :emitted_function   => hook_emitted_function]
-    if VERSION < v"1.5.0-DEV.423"
+    if VERSION < v"1.5.0-DEV.393"
         push!(param_kwargs, :cached => false)
     end
     if LLVM.version() >= v"8.0" && VERSION >= v"1.3.0-DEV.547"

--- a/src/compiler/irgen.jl
+++ b/src/compiler/irgen.jl
@@ -119,8 +119,7 @@ function compile_method_instance(job::CompilerJob, method_instance::Core.MethodI
         @compiler_assert last(call_stack) == method job
         last_method_instance = pop!(call_stack)
     end
-    param_kwargs = [:cached             => false,
-                    :track_allocations  => false,
+    param_kwargs = [:track_allocations  => false,
                     :code_coverage      => false,
                     :static_alloc       => false,
                     :prefer_specsig     => true,
@@ -128,6 +127,9 @@ function compile_method_instance(job::CompilerJob, method_instance::Core.MethodI
                     :module_activation  => hook_module_activation,
                     :emit_function      => hook_emit_function,
                     :emitted_function   => hook_emitted_function]
+     if VERSION >= v"1.5.0-DEV.423"
+        push!(param_kwargs, :cached => false)
+    end
     if LLVM.version() >= v"8.0" && VERSION >= v"1.3.0-DEV.547"
         push!(param_kwargs, :gnu_pubnames => false)
 

--- a/test/base.jl
+++ b/test/base.jl
@@ -15,7 +15,7 @@ end
 
 # bug: default module activation segfaulted on NULL child function if cached=false
 
-if VERSION >= v"1.5.0-DEV.423"
+if VERSION >= v"1.5.0-DEV.393"
     params = Base.CodegenParams()
 else
     params = Base.CodegenParams(cached=false)

--- a/test/base.jl
+++ b/test/base.jl
@@ -14,7 +14,13 @@ function post17057_parent(arr::Ptr{Int64})
 end
 
 # bug: default module activation segfaulted on NULL child function if cached=false
-params = Base.CodegenParams(cached=false)
+
+if VERSION >= v"1.5.0-DEV.423"
+    params = Base.CodegenParams()
+else
+    params = Base.CodegenParams(cached=false)
+end
+
 if VERSION >= v"1.1.0-DEV.762"
     _dump_function(post17057_parent, Tuple{Ptr{Int64}},
                    #=native=#false, #=wrapper=#false, #=strip=#false,


### PR DESCRIPTION
My aim is to handle the removal of `cached` in https://github.com/JuliaLang/julia/commit/3b53f54a5e612cfc402f561d71cdbfb40da3529e#diff-ca03aefbdf6018c4da887b6ec35e0027

The specific build number might be wrong (I took yesterdays build number and subtracted 8).