### PR TITLE
Support for Julia's multitasking.

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -81,6 +81,7 @@ uuid = "929cbde3-209d-540e-8aea-75f648917ca0"
 version = "1.3.4"
 
 [[LibGit2]]
+deps = ["Printf"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
 
 [[Libdl]]
@@ -113,7 +114,7 @@ uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 version = "1.1.0"
 
 [[Pkg]]
-deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Test", "UUIDs"]
+deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [[Printf]]

--- a/src/CUDAnative.jl
+++ b/src/CUDAnative.jl
@@ -111,7 +111,10 @@ function __init__()
     resize!(thread_contexts, Threads.nthreads())
     fill!(thread_contexts, nothing)
 
-    CUDAdrv.initializer(initialize_context)
+    resize!(thread_tasks, Threads.nthreads())
+    fill!(thread_tasks, nothing)
+
+    CUDAdrv.initializer(prepare_cuda_call)
 end
 
 function __configure__(show_reason::Bool)

--- a/src/cupti/error.jl
+++ b/src/cupti/error.jl
@@ -112,8 +112,7 @@ end
 end
 
 function initialize_api()
-    # make sure the calling thread has an active context
-    CUDAnative.initialize_context()
+    CUDAnative.prepare_cuda_call()
 end
 
 macro check(ex)

--- a/src/device/cuda/synchronization.jl
+++ b/src/device/cuda/synchronization.jl
@@ -43,7 +43,7 @@ for all threads of the block and returns `true` if and only if `predicate` evalu
 `true` for all of them.
 """
 @inline sync_threads_and(predicate::Int32) = ccall("llvm.nvvm.barrier0.and", llvmcall, Int32, (Int32,), predicate)
-@inline sync_threads_and(predicate::Bool) = ifelse(sync_threads_and(Int32(predicate)) !== Int32(0), true, false)
+@inline sync_threads_and(predicate::Bool) = ifelse(sync_threads_and(Int32(predicate)) != Int32(0), true, false)
 
 """
     sync_threads_or(predicate::Int32)
@@ -59,7 +59,7 @@ for all threads of the block and returns `true` if and only if `predicate` evalu
 `true` for any of them.
 """
 @inline sync_threads_or(predicate::Int32) = ccall("llvm.nvvm.barrier0.or", llvmcall, Int32, (Int32,), predicate)
-@inline sync_threads_or(predicate::Bool) = ifelse(sync_threads_or(Int32(predicate)) !== Int32(0), true, false)
+@inline sync_threads_or(predicate::Bool) = ifelse(sync_threads_or(Int32(predicate)) != Int32(0), true, false)
 
 """
     sync_warp(mask::Integer=0xffffffff)

--- a/src/exceptions.jl
+++ b/src/exceptions.jl
@@ -39,7 +39,7 @@ function check_exceptions()
         if CUDAdrv.isvalid(ctx)
             ptr = convert(Ptr{Int}, buf)
             flag = unsafe_load(ptr)
-            if flag !== 0
+            if flag != 0
                 unsafe_store!(ptr, 0)
                 dev = device(ctx)
                 throw(KernelException(dev))

--- a/src/init.jl
+++ b/src/init.jl
@@ -65,14 +65,13 @@ end
 const thread_tasks = Union{Nothing,WeakRef}[]
 @noinline function switched_tasks(tid::Int, task::Task)
     thread_tasks[tid] = WeakRef(task)
+    _attaskswitch(tid, task)
 
     # switch contexts if task switched to was already bound to one
     ctx = get(task_local_storage(), :CuContext, nothing)
     if ctx !== nothing
         context!(ctx)
     end
-
-    _attaskswitch(tid, task)
 end
 
 """

--- a/src/init.jl
+++ b/src/init.jl
@@ -85,7 +85,7 @@ Use this hook to invalidate thread-local state that depends on the current task.
 """
 attaskswitch(f::Function) = (pushfirst!(task_hooks, f); nothing)
 const task_hooks = []
-_attaskswitch(tid, task) = foreach(listener->listener(tid, task), task_hooks)
+_attaskswitch(tid, task) = foreach(f->Base.invokelatest(f, tid, task), task_hooks)
 
 
 ## context-based API
@@ -147,7 +147,7 @@ Use this hook to invalidate thread-local state that depends on the current devic
 """
 atcontextswitch(f::Function) = (pushfirst!(context_hooks, f); nothing)
 const context_hooks = []
-_atcontextswitch(tid, ctx) = foreach(listener->listener(tid, ctx), context_hooks)
+_atcontextswitch(tid, ctx) = foreach(f->Base.invokelatest(f, tid, ctx), context_hooks)
 
 
 ## device-based API

--- a/src/init.jl
+++ b/src/init.jl
@@ -72,6 +72,8 @@ const thread_tasks = Union{Nothing,WeakRef}[]
     if ctx !== nothing
         context!(ctx)
     end
+    # NOTE: deactivating the context in the case ctx===nothing would be more correct,
+    #       but that confuses CUDA and leads to invalid contexts later on.
 end
 
 """

--- a/src/init.jl
+++ b/src/init.jl
@@ -46,7 +46,7 @@ const default_device = Ref{Union{Nothing,CuDevice}}(nothing)
 
 # CUDA uses thread-bound contexts, but calling CuCurrentContext all the time is expensive,
 # so we maintain our own thread-local state keeping track of the current context.
-const thread_contexts = Union{Nothing,CuContext}[] # TODO: WeakRef
+const thread_contexts = Union{Nothing,CuContext}[]
 @noinline function initialize_thread(tid::Int)
     ctx = CuCurrentContext()
     if ctx === nothing

--- a/src/init.jl
+++ b/src/init.jl
@@ -136,6 +136,23 @@ function context!(ctx::CuContext)
 end
 
 """
+    context!(f, ctx)
+
+Sets the active context for the duration of `f`.
+"""
+function context!(f::Function, ctx::CuContext)
+    old_ctx = CuCurrentContext()
+    try
+        context!(ctx)
+        f()
+    finally
+        if old_ctx != nothing
+            context!(old_ctx)
+        end
+    end
+end
+
+"""
     CUDAnative.atcontextswitch(f::Function)
 
 Register a function to be called after switching contexts on a thread. The function is

--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -171,7 +171,7 @@ function code_sass(io::IO, job::CompilerJob; verbose::Bool=false)
     if res === CUPTI.CUPTI_ERROR_INSUFFICIENT_PRIVILEGES
         error("""Insufficient priviliges: You don't have permissions to profile GPU code, which is required for `code_sass`.
                  Get administrative priviles or allow all users to profile: https://developer.nvidia.com/ERR_NVGPUCTRPERM#SolnAdminTag""")
-    elseif res !== CUPTI.CUPTI_SUCCESS
+    elseif res != CUPTI.CUPTI_SUCCESS
         throw(CUPTIError(res))
     end
     subscriber = subscriber_ref[]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -63,6 +63,11 @@ if length(devices()) > 0
         nothing
     end
 
+    context!(ctx)
+    context!(ctx) do
+        nothing
+    end
+
     @test_throws AssertionError device!(0, CUDAdrv.CU_CTX_SCHED_YIELD)
 
     device_reset!()


### PR DESCRIPTION
This PR makes CUDAnative aware of Julia's task execution model, and generalizes the initialization code (which now was only aware of threads, and the fact that each thread can independently switch contexts as far as CUDA is concerned) to take tasks into account. This makes it possible to have each task work with a different device, seamlessly switching contexts when execution switches from one task to another. The code should also work in the case tasks migrate between threads.

```
julia> using CUDAnative, CUDAdrv

julia> device!(0)

julia> @info "Task $(current_task()) on thread $(Threads.threadid()) is working on device $(device())"
[ Info: Task Task (runnable) @0x00007f8ad533b820 on thread 1 is working on device CuDevice(0): GeForce RTX 2080 Ti

julia> @async begin
       device!(1)
       @info "Task $(current_task()) on thread $(Threads.threadid()) is working on device $(device())"
       end
[ Info: Task Task (runnable) @0x00007f8a678c4280 on thread 1 is working on device CuDevice(1): GeForce GTX 1080
Task (done) @0x00007f8a678c4280

julia> @info "Task $(current_task()) on thread $(Threads.threadid()) is working on device $(device())"
[ Info: Task Task (runnable) @0x00007f8ad533b820 on thread 1 is working on device CuDevice(0): GeForce RTX 2080 Ti
```

```
julia> Threads.@threads for dev in collect(devices())
       device!(dev)
       @info "Task $(current_task()) on thread $(Threads.threadid()) is working on device $(device())"
       end
[ Info: Task Task (runnable) @0x00007f8a675e7a90 on thread 2 is working on device CuDevice(1): GeForce GTX 1080
[ Info: Task Task (runnable) @0x00007f8a675e7820 on thread 1 is working on device CuDevice(0): GeForce RTX 2080 Ti

julia> @info "Task $(current_task()) on thread $(Threads.threadid()) is working on device $(device())"
[ Info: Task Task (runnable) @0x00007f8ad533b820 on thread 1 is working on device CuDevice(0): GeForce RTX 2080 Ti
```

The way this works is that `prepare_cuda_call` takes care of synchronizing task-local properties to CUDA's thread-local state. This function should be called before any API call that assumes thread-local state, and is designed to be very fast (15ns on my system).

Finally, the PR also adds hooks `attaskswitch` and `atcontextswitch` for users to detect changes that impact thread-local state, in the case they need to maintain their own state too (e.g. for libraries with similar global thread-local state).