### PR TITLE
Avoid address space casts.

### DIFF
--- a/src/device/cuda.jl
+++ b/src/device/cuda.jl
@@ -11,7 +11,9 @@ include("cuda/assertion.jl")
 include("cuda/memory_dynamic.jl")
 include("cuda/atomics.jl")
 include("cuda/misc.jl")
+if VERSION >= v"1.4.1"
 include("cuda/wmma.jl")
+end
 
 # functionality from libdevice
 #

--- a/src/device/cuda/memory_shared.jl
+++ b/src/device/cuda/memory_shared.jl
@@ -61,7 +61,6 @@ end
     end
 
     T_ptr = convert(LLVMType, DevicePtr{T,AS.Shared})
-    T_actual_ptr = LLVM.PointerType(eltyp)
 
     # create a function
     llvm_f, _ = create_function(T_ptr)
@@ -92,10 +91,9 @@ end
         entry = BasicBlock(llvm_f, "entry", JuliaContext())
         position!(builder, entry)
 
-        ptr_with_as = gep!(builder, gv, [ConstantInt(0, JuliaContext()),
-                                         ConstantInt(0, JuliaContext())])
+        ptr = gep!(builder, gv, [ConstantInt(0, JuliaContext()),
+                                 ConstantInt(0, JuliaContext())])
 
-        ptr = addrspacecast!(builder, ptr_with_as, T_actual_ptr)
         val = ptrtoint!(builder, ptr, T_ptr)
         ret!(builder, val)
     end

--- a/test/device/cuda.jl
+++ b/test/device/cuda.jl
@@ -1133,6 +1133,17 @@ end
     end
 end
 
+@testset "shared memory" begin
+    function kernel()
+        shared = @cuStaticSharedMem(Float32, 1)
+        @atomic shared[threadIdx().x] += 0f0
+        return
+    end
+
+    @cuda kernel()
+    synchronize()
+end
+
 end
 
 end

--- a/test/device/wmma.jl
+++ b/test/device/wmma.jl
@@ -1,6 +1,5 @@
 # Need https://github.com/JuliaLang/julia/pull/33970
 # and  https://github.com/JuliaLang/julia/pull/34043
-if VERSION >= v"1.4.0-DEV.666" && capability(device()) >= v"7.0"
 
 using CUDAnative.WMMA
 
@@ -293,5 +292,4 @@ end
 
 ################################################################################
 
-end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,7 +33,9 @@ include("device/execution.jl")
 include("device/pointer.jl")
 include("device/array.jl")
 include("device/cuda.jl")
+if VERSION >= v"1.4.1" && capability(device()) >= v"7.0"
 include("device/wmma.jl")
+end
 
 include("nvtx.jl")
 


### PR DESCRIPTION
This PR changes how we work with and store address-space pointers: instead of casting them to and from generic pointers, directly work with their in-address space representation. That means we don't have to `addrspacecast` anymore, just `inttoptr ... addrspace(...)*` directly.

For WMMA, this requires 1.5's Base.AddrSpacePtr, because otherwise we select intrinsics for the generic case which leads to illegal memory accesses (cc @thomasfaingnaert).

Fixes https://github.com/JuliaGPU/CUDAnative.jl/issues/641.